### PR TITLE
Sort jdbc drivers

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -116,29 +116,6 @@ public class JdbcManageComposite extends
 			map.put("1", url);
 			jdbcListData.add(map);
 		}
-		jdbcInfoTv.setComparator(new ViewerComparator(){
-			public int compare(Viewer viewer, Object e1, Object e2){
-				Map<String, String> map1 = (Map<String, String>)e1;
-				Map<String, String> map2 = (Map<String, String>)e2;
-				
-				String version1 = map1.get("0");
-				String version2 = map2.get("0");
-				String[] version1Tokens = version1.substring(version1.lastIndexOf('-')+1).split("\\.");
-				String[] version2Tokens = version2.substring(version2.lastIndexOf('-')+1).split("\\.");
-				
-				int size = Math.min(version1Tokens.length, version2Tokens.length);
-				
-				for(int i = 0; i < size; i++){
-					Integer first = Integer.parseInt(version1Tokens[i]);
-					Integer second = Integer.parseInt(version2Tokens[i]);
-					if(first != second){
-						return second-first;
-					}
-				}
-				return version1Tokens.length == version2Tokens.length ? 
-						0 : (version2Tokens.length - version1Tokens.length);
-			}
-		});
 		jdbcInfoTv.refresh();
 		CommonUITool.packTable(jdbcInfoTv);
 	}
@@ -164,7 +141,31 @@ public class JdbcManageComposite extends
 	private void createJdbcTableGroup(Composite composite) {
 		final String[] columnNameArr = new String[]{
 				Messages.tblColDriverVersion, Messages.tblColJarPath };
+		
 		TableViewerSorter sorter = new TableViewerSorter();
+		sorter.setColumnComparator(0, new ViewerComparator(){
+			public int compare(Viewer viewer, Object e1, Object e2){
+				Map<String, String> map1 = (Map<String, String>)e1;
+				Map<String, String> map2 = (Map<String, String>)e2;
+				
+				String version1 = map1.get("0");
+				String version2 = map2.get("0");
+				String[] version1Tokens = version1.substring(version1.lastIndexOf('-')+1).split("\\.");
+				String[] version2Tokens = version2.substring(version2.lastIndexOf('-')+1).split("\\.");
+				
+				int size = Math.min(version1Tokens.length, version2Tokens.length);
+				
+				for(int i = 0; i < size; i++){
+					Integer first = Integer.parseInt(version1Tokens[i]);
+					Integer second = Integer.parseInt(version2Tokens[i]);
+					if(first != second){
+						return second-first;
+					}
+				}
+				return version1Tokens.length == version2Tokens.length ? 
+						0 : (version2Tokens.length - version1Tokens.length);
+			}
+		});
 		sorter.setAsc(false);
 		jdbcInfoTv = CommonUITool.createCommonTableViewer(composite, sorter,
 				columnNameArr,

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -30,6 +30,7 @@ package com.cubrid.common.ui.common.preference;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -143,15 +144,10 @@ public class JdbcManageComposite extends
 				Messages.tblColDriverVersion, Messages.tblColJarPath };
 		
 		TableViewerSorter sorter = new TableViewerSorter();
-		sorter.setColumnComparator(0, new ViewerComparator(){
-			public int compare(Viewer viewer, Object e1, Object e2){
-				Map<String, String> map1 = (Map<String, String>)e1;
-				Map<String, String> map2 = (Map<String, String>)e2;
-				
-				String version1 = map1.get("0");
-				String version2 = map2.get("0");
-				String[] version1Tokens = version1.substring(version1.lastIndexOf('-')+1).split("\\.");
-				String[] version2Tokens = version2.substring(version2.lastIndexOf('-')+1).split("\\.");
+		sorter.setColumnComparator(0, new Comparator<String>(){
+			public int compare(String s1, String s2){
+				String[] version1Tokens = s1.substring(s1.lastIndexOf('-')+1).split("\\.");
+				String[] version2Tokens = s2.substring(s2.lastIndexOf('-')+1).split("\\.");
 				
 				int size = Math.min(version1Tokens.length, version2Tokens.length);
 				

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -43,8 +43,6 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TableLayout;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -126,15 +126,17 @@ public class JdbcManageComposite extends
 				String[] version1Tokens = version1.substring(version1.lastIndexOf('-')+1).split("\\.");
 				String[] version2Tokens = version2.substring(version2.lastIndexOf('-')+1).split("\\.");
 				
-				for(int i = 0; i < version1Tokens.length; i++){
+				int size = Math.min(version1Tokens.length, version2Tokens.length);
+				
+				for(int i = 0; i < size; i++){
 					Integer first = Integer.parseInt(version1Tokens[i]);
 					Integer second = Integer.parseInt(version2Tokens[i]);
 					if(first != second){
 						return second-first;
 					}
 				}
-				
-				return 0;
+				return version1Tokens.length == version2Tokens.length ? 
+						0 : (version2Tokens.length - version1Tokens.length);
 			}
 		});
 		jdbcInfoTv.refresh();

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -144,22 +144,29 @@ public class JdbcManageComposite extends
 				Messages.tblColDriverVersion, Messages.tblColJarPath };
 		
 		TableViewerSorter sorter = new TableViewerSorter();
-		sorter.setColumnComparator(0, new Comparator<String>(){
-			public int compare(String s1, String s2){
-				String[] version1Tokens = s1.substring(s1.lastIndexOf('-')+1).split("\\.");
-				String[] version2Tokens = s2.substring(s2.lastIndexOf('-')+1).split("\\.");
+		sorter.setColumnComparator(0, new Comparator<Object>(){
+			public int compare(Object o1, Object o2){
+				if(o1 instanceof String && o2 instanceof String){
+					String s1 = (String)o1;
+					String s2 = (String)o2;
 				
-				int size = Math.min(version1Tokens.length, version2Tokens.length);
-				
-				for(int i = 0; i < size; i++){
-					Integer first = Integer.parseInt(version1Tokens[i]);
-					Integer second = Integer.parseInt(version2Tokens[i]);
-					if(first != second){
-						return second-first;
+					String[] version1Tokens = s1.substring(s1.lastIndexOf('-')+1).split("\\.");
+					String[] version2Tokens = s2.substring(s2.lastIndexOf('-')+1).split("\\.");
+					
+					int size = Math.min(version1Tokens.length, version2Tokens.length);
+					
+					for(int i = 0; i < size; i++){
+						Integer first = Integer.parseInt(version1Tokens[i]);
+						Integer second = Integer.parseInt(version2Tokens[i]);
+						if(first != second){
+							return second-first;
+						}
 					}
+					return version1Tokens.length == version2Tokens.length ? 
+							0 : (version2Tokens.length - version1Tokens.length);
+				} else {
+					return 0;
 				}
-				return version1Tokens.length == version2Tokens.length ? 
-						0 : (version2Tokens.length - version1Tokens.length);
 			}
 		});
 		sorter.setAsc(false);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -42,6 +42,8 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TableLayout;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -114,6 +116,27 @@ public class JdbcManageComposite extends
 			map.put("1", url);
 			jdbcListData.add(map);
 		}
+		jdbcInfoTv.setComparator(new ViewerComparator(){
+			public int compare(Viewer viewer, Object e1, Object e2){
+				Map<String, String> map1 = (Map<String, String>)e1;
+				Map<String, String> map2 = (Map<String, String>)e2;
+				
+				String version1 = map1.get("0");
+				String version2 = map2.get("0");
+				String[] version1Tokens = version1.substring(version1.lastIndexOf('-')+1).split("\\.");
+				String[] version2Tokens = version2.substring(version2.lastIndexOf('-')+1).split("\\.");
+				
+				for(int i = 0; i < version1Tokens.length; i++){
+					Integer first = Integer.parseInt(version1Tokens[i]);
+					Integer second = Integer.parseInt(version2Tokens[i]);
+					if(first != second){
+						return second-first;
+					}
+				}
+				
+				return 0;
+			}
+		});
 		jdbcInfoTv.refresh();
 		CommonUITool.packTable(jdbcInfoTv);
 	}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -160,8 +160,7 @@ public class JdbcManageComposite extends
 							return second-first;
 						}
 					}
-					return version1Tokens.length == version2Tokens.length ? 
-							0 : (version2Tokens.length - version1Tokens.length);
+					return version2Tokens.length - version1Tokens.length;
 				} else {
 					return 0;
 				}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/JdbcManageComposite.java
@@ -157,10 +157,10 @@ public class JdbcManageComposite extends
 						Integer first = Integer.parseInt(version1Tokens[i]);
 						Integer second = Integer.parseInt(version2Tokens[i]);
 						if(first != second){
-							return second-first;
+							return first-second;
 						}
 					}
-					return version2Tokens.length - version1Tokens.length;
+					return version1Tokens.length - version2Tokens.length;
 				} else {
 					return 0;
 				}
@@ -171,6 +171,8 @@ public class JdbcManageComposite extends
 				columnNameArr,
 				CommonUITool.createGridData(GridData.FILL_BOTH, 3, 1, -1, 200));
 		jdbcInfoTv.setInput(jdbcListData);
+		jdbcInfoTv.getTable().setSortColumn(jdbcInfoTv.getTable().getColumn(0));
+		jdbcInfoTv.getTable().setSortDirection(sorter.isAsc() ? SWT.UP : SWT.DOWN);
 
 		TableLayout tableLayout = new TableLayout();
 		jdbcInfoTv.getTable().setLayout(tableLayout);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
@@ -50,14 +50,14 @@ public class TableViewerSorter extends
 	protected int column;
 	protected int direction;
 	
-	private Map<Integer, Comparator<String>> columnComparators;
+	private Map<Integer, Comparator<Object>> columnComparators;
 	
-	public TableViewerSorter(Map<Integer, Comparator<String>> columnComparators){
+	public TableViewerSorter(Map<Integer, Comparator<Object>> columnComparators){
 		this.columnComparators = columnComparators;
 	}
 	
 	public TableViewerSorter(){
-		columnComparators = new HashMap<Integer, Comparator<String>>();
+		columnComparators = new HashMap<Integer, Comparator<Object>>();
 	}
 
 	/**
@@ -96,7 +96,11 @@ public class TableViewerSorter extends
 		Map map2 = (Map) e2;
 		Object obj1 = map1.get("" + column);
 		Object obj2 = map2.get("" + column);
-		if (obj1 instanceof Number && obj2 instanceof Number) {
+		Comparator<Object> comparator = columnComparators.get(column);
+		
+		if (comparator != null) {
+			rc = comparator.compare (obj1, obj2);
+		}else if (obj1 instanceof Number && obj2 instanceof Number) {
 			Number num1 = (Number) obj1;
 			Number num2 = (Number) obj2;
 			if (num1.doubleValue() > num2.doubleValue()) {
@@ -109,13 +113,7 @@ public class TableViewerSorter extends
 		} else if (obj1 instanceof String && obj2 instanceof String) {
 			String str1 = (String) obj1;
 			String str2 = (String) obj2;
-			
-			Comparator<String> comparator;
-			if((comparator = columnComparators.get(column)) != null){
-				rc = comparator.compare(str1, str2);
-			}else{
-				rc = str1.compareTo(str2);
-			}
+			rc = str1.compareTo(str2);
 		} else {
 			return 0;
 		}
@@ -144,7 +142,7 @@ public class TableViewerSorter extends
 		}
 	}
 	
-	public void setColumnComparator(Integer column, Comparator<String> comparator){
+	public void setColumnComparator(Integer column, Comparator<Object> comparator){
 		columnComparators.put(column, comparator);
 	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
@@ -49,9 +49,9 @@ public class TableViewerSorter extends
 	protected int column;
 	protected int direction;
 	
-	private Map<Integer, Comparator<Object>> columnComparators;
+	private HashMap<Integer, Comparator<Object>> columnComparators;
 	
-	public TableViewerSorter(Map<Integer, Comparator<Object>> columnComparators){
+	public TableViewerSorter(HashMap<Integer, Comparator<Object>> columnComparators){
 		this.columnComparators = columnComparators;
 	}
 	

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
@@ -27,9 +27,11 @@
  */
 package com.cubrid.common.ui.spi;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerSorter;
 
 /**
@@ -43,9 +45,19 @@ public class TableViewerSorter extends
 		ViewerSorter {
 	protected static final int ASCENDING = 0;
 	protected static final int DESCENDING = 1;
-
+;
 	protected int column;
 	protected int direction;
+	
+	private Map<Integer, ViewerComparator> columnComparators;
+	
+	public TableViewerSorter(Map<Integer, ViewerComparator> columnComparators){
+		this.columnComparators = columnComparators;
+	}
+	
+	public TableViewerSorter(){
+		columnComparators = new HashMap<Integer, ViewerComparator>();
+	}
 
 	/**
 	 * Does the sort. If it's a different column from the previous sort, do an
@@ -79,6 +91,16 @@ public class TableViewerSorter extends
 			return 0;
 		}
 		int rc = 0;
+		if(columnComparators != null){
+			ViewerComparator viewerComparator;
+			if((viewerComparator = columnComparators.get(column)) != null){
+				rc = viewerComparator.compare(viewer, e1, e2);
+				if (direction == DESCENDING) {
+					rc = -rc;
+				}
+				return rc;
+			}
+		}
 		Map map1 = (Map) e1;
 		Map map2 = (Map) e2;
 		Object obj1 = map1.get("" + column);
@@ -121,5 +143,9 @@ public class TableViewerSorter extends
 		} else {
 			this.direction = DESCENDING;
 		}
+	}
+	
+	public void setColumnComparator(Integer column, ViewerComparator viewerComparator){
+		columnComparators.put(column, viewerComparator);
 	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
@@ -27,6 +27,7 @@
  */
 package com.cubrid.common.ui.spi;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,14 +50,14 @@ public class TableViewerSorter extends
 	protected int column;
 	protected int direction;
 	
-	private Map<Integer, ViewerComparator> columnComparators;
+	private Map<Integer, Comparator<String>> columnComparators;
 	
-	public TableViewerSorter(Map<Integer, ViewerComparator> columnComparators){
+	public TableViewerSorter(Map<Integer, Comparator<String>> columnComparators){
 		this.columnComparators = columnComparators;
 	}
 	
 	public TableViewerSorter(){
-		columnComparators = new HashMap<Integer, ViewerComparator>();
+		columnComparators = new HashMap<Integer, Comparator<String>>();
 	}
 
 	/**
@@ -91,16 +92,6 @@ public class TableViewerSorter extends
 			return 0;
 		}
 		int rc = 0;
-		if(columnComparators != null){
-			ViewerComparator viewerComparator;
-			if((viewerComparator = columnComparators.get(column)) != null){
-				rc = viewerComparator.compare(viewer, e1, e2);
-				if (direction == DESCENDING) {
-					rc = -rc;
-				}
-				return rc;
-			}
-		}
 		Map map1 = (Map) e1;
 		Map map2 = (Map) e2;
 		Object obj1 = map1.get("" + column);
@@ -118,7 +109,15 @@ public class TableViewerSorter extends
 		} else if (obj1 instanceof String && obj2 instanceof String) {
 			String str1 = (String) obj1;
 			String str2 = (String) obj2;
-			rc = str1.compareTo(str2);
+			
+			Comparator<String> comparator;
+			if((comparator = columnComparators.get(column)) != null){
+				rc = comparator.compare(str1, str2);
+			}else{
+				rc = str1.compareTo(str2);
+			}
+		} else {
+			return 0;
 		}
 		// If descending order, flip the direction
 		if (direction == DESCENDING) {
@@ -145,7 +144,7 @@ public class TableViewerSorter extends
 		}
 	}
 	
-	public void setColumnComparator(Integer column, ViewerComparator viewerComparator){
-		columnComparators.put(column, viewerComparator);
+	public void setColumnComparator(Integer column, Comparator<String> comparator){
+		columnComparators.put(column, comparator);
 	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/TableViewerSorter.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jface.viewers.Viewer;
-import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerSorter;
 
 /**
@@ -46,7 +45,7 @@ public class TableViewerSorter extends
 		ViewerSorter {
 	protected static final int ASCENDING = 0;
 	protected static final int DESCENDING = 1;
-;
+
 	protected int column;
 	protected int direction;
 	
@@ -100,7 +99,7 @@ public class TableViewerSorter extends
 		
 		if (comparator != null) {
 			rc = comparator.compare (obj1, obj2);
-		}else if (obj1 instanceof Number && obj2 instanceof Number) {
+		} else if (obj1 instanceof Number && obj2 instanceof Number) {
 			Number num1 = (Number) obj1;
 			Number num2 = (Number) obj2;
 			if (num1.doubleValue() > num2.doubleValue()) {


### PR DESCRIPTION
This fix solves the issue with the JDBC driver ordering in the Preferences/JDBC Management tab. At first, they were ordered alphabetically and that was not desired, so I have ordered them based on the version number.

TableViewerSorter.java now contains a hashmap that can have an arbitrary comparator for each table column (the key of this hashmap is the column value). When sorting a column, I check whether the hashmap contains a comparator for that column or not and, if it exists, use it.