### PR TITLE
CloseQueryEditor: if all tabs are closed, start sqlEditorCounter at 1

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/editor/QueryEditorPart.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/editor/QueryEditorPart.java
@@ -998,6 +998,7 @@ public class QueryEditorPart extends
 		subQueryEditorTabItem.addDisposeListener(new DisposeListener() {
 			public void widgetDisposed(DisposeEvent e) {
 				if (!willClose && combinedQueryEditortabFolder.getItemCount() == 0) {
+					sqlEditorCounter = 1;
 					addEditorTab();
 				}
 			}


### PR DESCRIPTION
Very small improvement: when closing the last sql editor, the counter would just increment. Now, if it's the last one and you close it, the counter just gets reset to 1.