### PR TITLE
Auto layout button

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
@@ -111,6 +111,7 @@ public class ERSchemaToolBar extends
 	 * Init items on the tool bar
 	 */
 	public void init() {
+		setSize(computeSize(SWT.DEFAULT, 40));
 		loginState = erSchemaEditor.getDatabase().isLogined();
 		selectDbItem = new ToolItem(this, SWT.SEPARATOR);
 		Composite comp = createSelectDbLabel();
@@ -252,7 +253,7 @@ public class ERSchemaToolBar extends
 		autoLayoutItem = new ToolItem(this, SWT.SEPARATOR);
 		Composite autoLayoutComp = createAutoLayoutComp();
 		autoLayoutItem.setControl(autoLayoutComp);
-		autoLayoutItem.setWidth(100);
+		autoLayoutItem.setWidth(120);
 		new ToolItem(this, SWT.SEPARATOR | SWT.VERTICAL);
 
 		// search comp
@@ -409,15 +410,13 @@ public class ERSchemaToolBar extends
 	private Composite createAutoLayoutComp() {
 		Composite comp = new Composite(this, SWT.NONE);
 		final GridLayout gdLayout = new GridLayout(1, false);
-		gdLayout.marginHeight = 1;
-		gdLayout.marginWidth = 1;
-		gdLayout.horizontalSpacing = 2;
-		gdLayout.verticalSpacing = 0;
+		final GridData gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
+		
 		comp.setLayout(gdLayout);
-		comp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+		comp.setLayoutData(gridData);
 
-		final Button autoLayoutButton = new Button(comp, SWT.PUSH | SWT.CENTER);
-		autoLayoutButton.setLayoutData(CommonUITool.createGridData(1, 1, 98, 28));
+		final Button autoLayoutButton = new Button(comp, SWT.PUSH | SWT.CENTER | SWT.FILL);
+		autoLayoutButton.setLayoutData(gridData);
 		autoLayoutButton.setText(Messages.btnAutoLayout);
 		autoLayoutButton.addListener(SWT.Selection, new Listener() {
 			public void handleEvent(Event event) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
@@ -417,7 +417,7 @@ public class ERSchemaToolBar extends
 		comp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
 		final Button autoLayoutButton = new Button(comp, SWT.PUSH | SWT.CENTER);
-		autoLayoutButton.setLayoutData(CommonUITool.createGridData(1, 1, 98, 20));
+		autoLayoutButton.setLayoutData(CommonUITool.createGridData(1, 1, 98, 28));
 		autoLayoutButton.setText(Messages.btnAutoLayout);
 		autoLayoutButton.addListener(SWT.Selection, new Listener() {
 			public void handleEvent(Event event) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
@@ -39,6 +39,7 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
@@ -111,7 +112,7 @@ public class ERSchemaToolBar extends
 	 * Init items on the tool bar
 	 */
 	public void init() {
-		setSize(computeSize(SWT.DEFAULT, 40));
+		setSize(computeSize(SWT.DEFAULT, 35));
 		loginState = erSchemaEditor.getDatabase().isLogined();
 		selectDbItem = new ToolItem(this, SWT.SEPARATOR);
 		Composite comp = createSelectDbLabel();
@@ -416,6 +417,10 @@ public class ERSchemaToolBar extends
 		comp.setLayoutData(gridData);
 
 		final Button autoLayoutButton = new Button(comp, SWT.PUSH | SWT.CENTER | SWT.FILL);
+		Font font = autoLayoutButton.getFont();
+		String fontName = font.getFontData()[0].name;
+		int fontSize = (int)font.getFontData()[0].height;
+		autoLayoutButton.setFont(new Font(getDisplay(), fontName, fontSize - 1, SWT.NONE));
 		autoLayoutButton.setLayoutData(gridData);
 		autoLayoutButton.setText(Messages.btnAutoLayout);
 		autoLayoutButton.addListener(SWT.Selection, new Listener() {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
@@ -39,7 +39,6 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/editor/ERSchemaToolBar.java
@@ -112,7 +112,6 @@ public class ERSchemaToolBar extends
 	 * Init items on the tool bar
 	 */
 	public void init() {
-		setSize(computeSize(SWT.DEFAULT, 35));
 		loginState = erSchemaEditor.getDatabase().isLogined();
 		selectDbItem = new ToolItem(this, SWT.SEPARATOR);
 		Composite comp = createSelectDbLabel();
@@ -411,16 +410,13 @@ public class ERSchemaToolBar extends
 	private Composite createAutoLayoutComp() {
 		Composite comp = new Composite(this, SWT.NONE);
 		final GridLayout gdLayout = new GridLayout(1, false);
+		gdLayout.marginHeight = 0;
 		final GridData gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
 		
 		comp.setLayout(gdLayout);
 		comp.setLayoutData(gridData);
 
 		final Button autoLayoutButton = new Button(comp, SWT.PUSH | SWT.CENTER | SWT.FILL);
-		Font font = autoLayoutButton.getFont();
-		String fontName = font.getFontData()[0].name;
-		int fontSize = (int)font.getFontData()[0].height;
-		autoLayoutButton.setFont(new Font(getDisplay(), fontName, fontSize - 1, SWT.NONE));
 		autoLayoutButton.setLayoutData(gridData);
 		autoLayoutButton.setText(Messages.btnAutoLayout);
 		autoLayoutButton.addListener(SWT.Selection, new Listener() {


### PR DESCRIPTION
This commit fixes the "Auto layout" button's height so that its text is shown fully. This button is found in Pro Tools->ERD Editor
![autolayout](https://cloud.githubusercontent.com/assets/17722852/21148229/3ffc7b48-c160-11e6-8ef7-c068e0c7014a.png)
