### PR TITLE
ExecuteSQLWindow: fix the query text box

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/PstmtSQLDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/PstmtSQLDialog.java
@@ -183,7 +183,7 @@ public class PstmtSQLDialog extends CMTitleAreaDialog implements ITaskExecutorIn
 			sashForm.setOrientation(SWT.VERTICAL);
 			GridData gridData = new GridData(GridData.FILL_BOTH);
 			gridData.widthHint = 600;
-			gridData.heightHint = 400;
+			gridData.heightHint = 600;
 			sashForm.setLayoutData(gridData);
 			GridLayout layout = new GridLayout();
 			layout.horizontalSpacing = convertHorizontalDLUsToPixels(IDialogConstants.HORIZONTAL_SPACING);
@@ -192,7 +192,7 @@ public class PstmtSQLDialog extends CMTitleAreaDialog implements ITaskExecutorIn
 			createSqlTextComposite(sashForm);
 			createBottomComposite(sashForm);
 
-			sashForm.setWeights(new int[]{25, 75});
+			sashForm.setWeights(new int[]{50, 50});
 		}
 		if (isInsert) {
 			initial();


### PR DESCRIPTION
The execute defined sql text box is too small for its function.
![execute](https://cloud.githubusercontent.com/assets/17722852/21225656/86e2edb4-c2da-11e6-8abb-b36581631979.png)

By making the widget bigger and by giving the sql text box part a 50% area, the sql text box now looks ok.
![executefix](https://cloud.githubusercontent.com/assets/17722852/21225710/bc1f94d2-c2da-11e6-913f-1395fc5d1df7.png)
