### PR TITLE
Enhancement for Export function

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
@@ -636,4 +636,41 @@ public final class QueryUtil {
 
 		return m.group(2);
 	}
+	
+	public static String getSelectSQL(Connection conn, String name) {
+		String sql = null;
+		List<String> columnList = getColumnList(conn, name);
+		StringBuffer columns = new StringBuffer();
+		int size = columnList.size();
+		for (int i = 0; i < columnList.size(); i++) {
+			columns.append(QuerySyntax.escapeKeyword(columnList.get(i)));
+			if (i != size - 1) {
+				columns.append(',');
+			}
+		}
+		sql = "SELECT " + columns + " FROM " + QuerySyntax.escapeKeyword(name);
+		return sql;
+	}
+	
+	public static List<String> getColumnList(Connection conn, String tableName) {
+		List<String> columnList = new ArrayList<String>();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		String sql = "SELECT attr_name FROM db_attribute WHERE class_name = ?";
+		
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, tableName);
+			rs = pstmt.executeQuery();
+			while (rs.next()) {
+				columnList.add(QuerySyntax.escapeKeyword(rs.getString(1)));
+			}
+		} catch (SQLException e) {
+			LOGGER.error(e.getLocalizedMessage());
+		} finally {
+			QueryUtil.freeQuery(pstmt, rs);
+		}
+		
+		return columnList;
+	}
 }

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
@@ -640,7 +640,7 @@ public final class QueryUtil {
 	public static String getSelectSQL(Connection conn, String name) {
 		String sql = null;
 		List<String> columnList = getColumnList(conn, name);
-		StringBuffer columns = new StringBuffer();
+		StringBuilder columns = new StringBuilder();
 		int size = columnList.size();
 		for (int i = 0; i < columnList.size(); i++) {
 			columns.append(QuerySyntax.escapeKeyword(columnList.get(i)));

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages.properties
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages.properties
@@ -844,7 +844,7 @@ titleImportStep2=Configure the importing options
 titleImportStep3=Confirm the importing options
 titleExportStep1=Choose the exporting type
 titleExportStep2=Configure the exporting options
-titleExportStep3=Confirm the importing options
+titleExportStep3=Confirm the exporting options
 importWizardComfimrDescription=Confirm the importing options
 
 defaultExportHistoryName=[{1}] DB:{0}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportConfigManager.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportConfigManager.java
@@ -119,12 +119,9 @@ public class ExportConfigManager {
 					String tableName = tables[j].getString("name");
 					tableList.add(tableName);
 					String whereCondition = tables[j].getString("where");
-					String[] columns = tables[j].getString("columns").split(",");
 					if (whereCondition != null && whereCondition.trim().length() > 0) {
 						tableWhereConditionMap.put(tableName, whereCondition);
 					}
-					List<String> colList = Arrays.asList(columns);
-					exportTableColumnMap.put(tableName, colList);
 				}
 
 				ExportConfig model = new ExportConfig();
@@ -197,12 +194,8 @@ public class ExportConfigManager {
 
 				List<String> tableList = model.getTableNameList();
 				for (String tableName : tableList) {
-					List<String> colList = model.getColumnNameList(tableName);
-					String[] cols = new String[colList.size()];
-					String colNames = StringUtil.implode(",", colList.toArray(cols));
 					IXMLMemento tableMemento = configMemento.createChild("table");
 					tableMemento.putString("name", tableName);
-					tableMemento.putString("columns", colNames);
 					String whereCondition = model.getWhereCondition(tableName);
 					if (StringUtil.isNotEmpty(whereCondition)) {
 						tableMemento.putString("where", whereCondition);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingForLoadDBPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingForLoadDBPage.java
@@ -240,7 +240,6 @@ public class ExportSettingForLoadDBPage extends
 				for (ICubridNode node : tablesOrViewLst) {
 					ctv.setGrayed(node, false);
 					ctv.setChecked(node, selection);
-					ctv.setSubtreeChecked(node, selection);
 				}
 				updateDialogStatus();
 			}
@@ -473,7 +472,6 @@ public class ExportSettingForLoadDBPage extends
 				for (ICubridNode node : tablesOrViewLst) {
 					if (table.equalsIgnoreCase(node.getName())) {
 						ctv.setChecked(node, true);
-						ctv.setSubtreeChecked(node, true);
 					}
 				}
 			}
@@ -929,7 +927,6 @@ public class ExportSettingForLoadDBPage extends
 		Object[] objects = ctv.getCheckedElements();
 		for (Object o : objects) {
 			ctv.setChecked(o, false);
-			ctv.setSubtreeChecked(o, false);
 		}
 		tablesOrViewLst.clear();
 	}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingForLoadDBPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingForLoadDBPage.java
@@ -37,10 +37,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.PageChangedEvent;
@@ -71,7 +69,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.Tree;
 import org.slf4j.Logger;
 
 import com.cubrid.common.core.util.ConstantsUtil;
@@ -85,14 +82,12 @@ import com.cubrid.common.ui.cubrid.table.Messages;
 import com.cubrid.common.ui.cubrid.table.progress.ExportConfig;
 import com.cubrid.common.ui.spi.model.DefaultSchemaNode;
 import com.cubrid.common.ui.spi.model.ICubridNode;
-import com.cubrid.common.ui.spi.model.ICubridNodeLoader;
 import com.cubrid.common.ui.spi.model.NodeType;
 import com.cubrid.common.ui.spi.persist.QueryOptions;
 import com.cubrid.common.ui.spi.util.CommonUITool;
 import com.cubrid.common.ui.spi.util.TableUtil;
 import com.cubrid.cubridmanager.core.common.jdbc.JDBCConnectionManager;
 import com.cubrid.cubridmanager.core.cubrid.database.model.DatabaseInfo;
-import com.cubrid.cubridmanager.core.cubrid.table.model.TableColumn;
 
 /**
  * The ExportSettingForLoadDBPage
@@ -177,50 +172,9 @@ public class ExportSettingForLoadDBPage extends
 		ctv.getTree().setLayoutData(CommonUITool.createGridData(GridData.FILL_BOTH, 1, 1, -1, -1));
 		ctv.setContentProvider(new FilterTreeContentProvider());
 
-		final Tree tableTree = ctv.getTree();
-		tableTree.setHeaderVisible(true);
-		tableTree.setLinesVisible(true);
-
 		ctv.addCheckStateListener(new ICheckStateListener() {
 			public void checkStateChanged(CheckStateChangedEvent event) {
-				ctv.setGrayed(event.getElement(), false);
-				ctv.setSubtreeChecked(event.getElement(), event.getChecked());
-				if (event.getElement() instanceof ICubridNode) {
-					ICubridNode node = (ICubridNode) event.getElement();
-					ICubridNode parent = node.getParent();
-					if (parent != null) {
-						changeParentNodeState(parent);
-					}
-				}
 				updateDialogStatus();
-			}
-
-			/**
-			 * Change parent node state based upon the children node state
-			 *
-			 * @param parent the parent node
-			 */
-			private void changeParentNodeState(ICubridNode parent) {
-				int checkedCount = 0;
-				Object[] objects = ctv.getCheckedElements();
-				List<ICubridNode> children = parent.getChildren();
-				for (ICubridNode child : children) {
-					for (Object obj : objects) {
-						ICubridNode checkedNode = (ICubridNode) obj;
-						if (child.getId().equals(checkedNode.getId())) {
-							checkedCount++;
-						}
-					}
-				}
-				if (checkedCount == 0) {
-					ctv.setChecked(parent, false);
-					ctv.setGrayed(parent, false);
-				} else if (!children.isEmpty() && checkedCount == children.size()) {
-					ctv.setChecked(parent, true);
-					ctv.setGrayed(parent, false);
-				} else {
-					ctv.setGrayChecked(parent, true);
-				}
 			}
 		});
 
@@ -487,15 +441,6 @@ public class ExportSettingForLoadDBPage extends
 						if (StringUtil.isNotEmpty(whereCondition)) {
 							node.setData(ExportObjectLabelProvider.CONDITION, whereCondition);
 						}
-						List<String> columnList = exportConfig.getColumnNameList(table);
-						for (ICubridNode columnNode : node.getChildren()) {
-							for (String columnName : columnList) {
-								if (columnNode.getName().equals(columnName)) {
-									ctv.setChecked(columnNode, true);
-									break;
-								}
-							}
-						}
 					}
 				}
 			}
@@ -621,69 +566,6 @@ public class ExportSettingForLoadDBPage extends
 						}
 						QueryUtil.freeQuery(rs);
 						monitor.worked(1);
-						monitor.subTask(Messages.taskLoadingColumn);
-
-						StringBuilder getColumnsSQL = new StringBuilder(
-								"SELECT attr_name, class_name, is_nullable ");
-						getColumnsSQL.append("FROM db_attribute WHERE class_name IN (");
-						for (int i = 0; i < tablesOrViewLst.size(); i++) {
-							if (i != 0) {
-								getColumnsSQL.append(" , ");
-							}
-							getColumnsSQL.append(" '").append(tablesOrViewLst.get(i).getName()).append(
-									"' ");
-						}
-						getColumnsSQL.append(") ORDER BY class_name, def_order");
-						query = getColumnsSQL.toString();
-
-						// [TOOLS-2425]Support shard broker
-						if (getDatabase() != null) {
-							query = DatabaseInfo.wrapShardQuery(getDatabase().getDatabaseInfo(),
-									query);
-						}
-
-						rs = stmt.executeQuery(query);
-
-						Map<String, List<TableColumn>> tableColumMap = new HashMap<String, List<TableColumn>>();
-						while (rs.next()) {
-							String columnName = rs.getString(1);
-							String className = rs.getString(2);
-							String nullAble = rs.getString(3);
-
-							List<TableColumn> columnList = tableColumMap.get(className);
-							if (columnList == null) {
-								columnList = new ArrayList<TableColumn>();
-								tableColumMap.put(className, columnList);
-							}
-							TableColumn dbColumn = new TableColumn();
-							dbColumn.setColumnName(columnName);
-							if ("YES".equals(nullAble)) {
-								dbColumn.setPrimaryKey(false);
-							} else {
-								dbColumn.setPrimaryKey(true);
-							}
-							columnList.add(dbColumn);
-						}
-
-						for (ICubridNode classNode : tablesOrViewLst) {
-							String tableName = classNode.getName();
-							List<TableColumn> columns = tableColumMap.get(tableName);
-							for (TableColumn column : columns) {
-								String label = column.getColumnName();
-								String columnId = tableName + ICubridNodeLoader.NODE_SEPARATOR
-										+ label;
-								ICubridNode columnNode = new DefaultSchemaNode(columnId, label,
-										"icons/navigator/table_column_item.png");
-								if (column.isPrimaryKey()) {
-									columnNode.setIconPath("icons/primary_key.png");
-								}
-								columnNode.setType(NodeType.TABLE_COLUMN);
-								columnNode.setContainer(false);
-								classNode.addChild(columnNode);
-							}
-
-						}
-						monitor.worked(1);
 					} catch (SQLException e) {
 						CommonUITool.openErrorBox(getShell(),
 								e.getErrorCode() + System.getProperty("line.separator")
@@ -800,25 +682,6 @@ public class ExportSettingForLoadDBPage extends
 				setErrorMessage(Messages.exportWizardLoadDBPageErrMsg7);
 				setPageComplete(false);
 				return;
-			}
-		}
-
-		Object[] objects = ctv.getCheckedElements();
-		for (Object object : objects) {
-			ICubridNode node = (ICubridNode) object;
-			if (node.getType() == NodeType.TABLE_COLUMN_FOLDER) {
-				boolean hasColumnChecked = false;
-				for (ICubridNode columnNode : node.getChildren()) {
-					if (ctv.getChecked(columnNode)) {
-						hasColumnChecked = true;
-						break;
-					}
-				}
-				if (!hasColumnChecked) {
-					setErrorMessage(Messages.bind(Messages.errorExportHistoryColumn, node.getName()));
-					setPageComplete(false);
-					return;
-				}
 			}
 		}
 

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
@@ -1236,21 +1236,6 @@ public class ExportSettingPage extends
 		for (ICubridNode tableOrView : selectedTableOrViews) {
 			String filePath = savedDirFile.getAbsolutePath() + File.separator
 					+ tableOrView.getName() + fileExt;
-			List<ICubridNode> columnNodes = tableOrView.getChildren();
-			ArrayList<String> columnNames = new ArrayList<String>();
-			for (ICubridNode columnNode : columnNodes) {
-				for (Object object : objects) {
-					ICubridNode node = (ICubridNode) object;
-					if (node.getType() == NodeType.TABLE_COLUMN) {
-						ICubridNode parent = node.getParent();
-						if (parent != null && parent.getId().equalsIgnoreCase(tableOrView.getId())
-								&& columnNode.getName().equalsIgnoreCase(node.getName())) {
-							columnNames.add(columnNode.getName());
-						}
-					}
-				}
-			}
-			exportConfig.setColumnNameList(tableOrView.getName(), columnNames);
 			Object whereCondition = tableOrView.getData(ExportObjectLabelProvider.CONDITION);
 			if (whereCondition != null) {
 				String sqlFilterPart = ((String) whereCondition).trim();

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
@@ -273,7 +273,6 @@ public class ExportSettingPage extends
 				for (ICubridNode node : tablesOrViewLst) {
 					treeViewer.setGrayed(node, false);
 					treeViewer.setChecked(node, selection);
-					treeViewer.setSubtreeChecked(node, selection);
 				}
 				updateDialogStatus(null);
 			}
@@ -1326,7 +1325,6 @@ public class ExportSettingPage extends
 		Object[] objects = treeViewer.getCheckedElements();
 		for (Object o : objects) {
 			treeViewer.setChecked(o, false);
-			treeViewer.setSubtreeChecked(o, false);
 		}
 		tablesOrViewLst.clear();
 	}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
@@ -75,7 +75,6 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.Tree;
 import org.slf4j.Logger;
 
 import com.cubrid.common.core.util.ConstantsUtil;
@@ -92,7 +91,6 @@ import com.cubrid.common.ui.spi.StatusInfo;
 import com.cubrid.common.ui.spi.model.CubridDatabase;
 import com.cubrid.common.ui.spi.model.DefaultSchemaNode;
 import com.cubrid.common.ui.spi.model.ICubridNode;
-import com.cubrid.common.ui.spi.model.ICubridNodeLoader;
 import com.cubrid.common.ui.spi.model.NodeType;
 import com.cubrid.common.ui.spi.persist.QueryOptions;
 import com.cubrid.common.ui.spi.util.CommonUITool;
@@ -698,15 +696,6 @@ public class ExportSettingPage extends
 						String whereCondition = exportConfig.getWhereCondition(table);
 						if (whereCondition != null) {
 							node.setData(ExportObjectLabelProvider.CONDITION, whereCondition);
-						}
-						List<String> columnList = exportConfig.getColumnNameList(table);
-						for (ICubridNode columnNode : node.getChildren()) {
-							for (String columnName : columnList) {
-								if (columnNode.getName().equals(columnName)) {
-									treeViewer.setChecked(columnNode, true);
-									break;
-								}
-							}
 						}
 					}
 				}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/AbsExportDataHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/AbsExportDataHandler.java
@@ -217,7 +217,7 @@ public abstract class AbsExportDataHandler {
 	}
 	
 	private List<String> getColumnList(String tableName) {
-		List<String> columnList = new ArrayList<>();
+		List<String> columnList = new ArrayList<String>();
 		CUBRIDPreparedStatementProxy pstmt = null;
 		CUBRIDResultSetProxy rs = null;
 		String sql = "SELECT attr_name FROM db_attribute WHERE class_name = ?";

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/AbsExportDataHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/AbsExportDataHandler.java
@@ -201,44 +201,6 @@ public abstract class AbsExportDataHandler {
 		}
 	}
 
-	protected String getSelectSQL(String name) { // FIXME move this logic to core module
-		String sql = null;
-		List<String> columnList = getColumnList(name);
-		StringBuffer columns = new StringBuffer();
-		int size = columnList.size();
-		for (int i = 0; i < columnList.size(); i++) {
-			columns.append(QuerySyntax.escapeKeyword(columnList.get(i)));
-			if (i != size - 1) {
-				columns.append(',');
-			}
-		}
-		sql = "SELECT " + columns + " FROM " + QuerySyntax.escapeKeyword(name);
-		return sql;
-	}
-	
-	private List<String> getColumnList(String tableName) {
-		List<String> columnList = new ArrayList<String>();
-		CUBRIDPreparedStatementProxy pstmt = null;
-		CUBRIDResultSetProxy rs = null;
-		String sql = "SELECT attr_name FROM db_attribute WHERE class_name = ?";
-		
-		try {
-			pstmt = (CUBRIDPreparedStatementProxy) getConnection()
-					.prepareStatement(sql);
-			pstmt.setString(1, tableName);
-			rs = (CUBRIDResultSetProxy) pstmt.executeQuery();
-			while (rs.next()) {
-				columnList.add(rs.getString(1));
-			}
-		} catch (SQLException e) {
-			LOGGER.error(e.getLocalizedMessage());
-		} finally {
-			QueryUtil.freeQuery(pstmt, rs);
-		}
-		
-		return columnList;
-	}
-
 	protected Connection getConnection() throws SQLException { // FIXME move this logic to core module
 		return JDBCConnectionManager.getConnection(dbInfo, false);
 	}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
@@ -143,6 +143,9 @@ public class ExportLoadDBHandler extends
 			for (String tableName : exportConfig.getTableNameList()) {
 				String whereCondition = exportConfig.getWhereCondition(tableName);
 				long totalRecord = exportConfig.getTotalCount(tableName);
+				if (totalRecord == 0) {
+					continue;
+				}
 				boolean hasNextPage = true;
 				int exportedCount = 0;
 				long beginIndex = 1;

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
@@ -149,7 +149,7 @@ public class ExportLoadDBHandler extends
 				boolean hasNextPage = true;
 				int exportedCount = 0;
 				long beginIndex = 1;
-				String sql = getSelectSQL(tableName);
+				String sql = QueryUtil.getSelectSQL(conn, tableName); 
 				isPaginating = isPagination(tableName, sql, whereCondition);
 				boolean isExportedColumnTitles = false;
 				while (hasNextPage) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
@@ -146,6 +146,7 @@ public class ExportLoadDBHandler extends
 				if (totalRecord == 0) {
 					continue;
 				}
+				
 				boolean hasNextPage = true;
 				int exportedCount = 0;
 				long beginIndex = 1;

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
@@ -120,7 +120,7 @@ public class ExportToTxtHandler extends
 			conn = getConnection();
 			fs = FileUtil.getBufferedWriter(exportConfig.getDataFilePath(tableName),
 					exportConfig.getFileCharset());
-			String sql = getSelectSQL(tableName);
+			String sql = QueryUtil.getSelectSQL(conn, tableName); 
 			isPaginating = isPagination(tableName, sql, whereCondition);
 			while (hasNextPage) {
 				try {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
@@ -107,6 +107,10 @@ public class ExportToTxtHandler extends
 		CUBRIDResultSetProxy rs = null;
 		boolean hasNextPage = true;
 		long totalRecord = exportConfig.getTotalCount(tableName);
+		if (totalRecord == 0) {
+			return;
+		}
+		
 		long beginIndex = 1;
 		int exportedCount = 0;
 		String whereCondition = exportConfig.getWhereCondition(tableName);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
@@ -93,6 +93,11 @@ public class ExportToTxtHandler extends
 			return;
 		}
 		
+		long totalRecord = exportConfig.getTotalCount(tableName);
+		if (totalRecord == 0) {
+			return;
+		}
+		
 		if(exportConfig.isExportFromCache()){
 			exportFromCache(tableName);
 		}else{
@@ -107,10 +112,6 @@ public class ExportToTxtHandler extends
 		CUBRIDResultSetProxy rs = null;
 		boolean hasNextPage = true;
 		long totalRecord = exportConfig.getTotalCount(tableName);
-		if (totalRecord == 0) {
-			return;
-		}
-		
 		long beginIndex = 1;
 		int exportedCount = 0;
 		String whereCondition = exportConfig.getWhereCondition(tableName);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
@@ -129,7 +129,7 @@ public class ExportToXlsHandler extends
 			WritableSheet sheet = workbook.createSheet("Sheet " + sheetNum, sheetNum);
 			sheetNum++;
 			int exportedCount = 0;
-			String sql = getSelectSQL(tableName);
+			String sql = QueryUtil.getSelectSQL(conn, tableName);
 			isPaginating = isPagination(whereCondition, sql, whereCondition);
 			while (hasNextPage) {
 				try {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
@@ -103,6 +103,11 @@ public class ExportToXlsHandler extends
 		if (StringUtil.isEmpty(tableName)) { // FIXME move this logic to core module
 			return;
 		}
+		
+		long totalRecord = exportConfig.getTotalCount(tableName);
+		if (totalRecord == 0) {
+			return;
+		}
 
 		Connection conn = null;
 		CUBRIDPreparedStatementProxy pStmt = null;
@@ -112,10 +117,6 @@ public class ExportToXlsHandler extends
 		String whereCondition = exportConfig.getWhereCondition(tableName);
 		boolean hasNextPage = true;
 		long beginIndex = 1;
-		long totalRecord = exportConfig.getTotalCount(tableName);
-		if (totalRecord == 0) {
-			return;
-		}
 		
 		int cellCharacterLimit = ImportFileConstants.XLSX_CELL_CHAR_LIMIT;
 		int rowLimit = ImportFileConstants.XLS_ROW_LIMIT; // 65536: limit xls row number.

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
@@ -113,6 +113,10 @@ public class ExportToXlsHandler extends
 		boolean hasNextPage = true;
 		long beginIndex = 1;
 		long totalRecord = exportConfig.getTotalCount(tableName);
+		if (totalRecord == 0) {
+			return;
+		}
+		
 		int cellCharacterLimit = ImportFileConstants.XLSX_CELL_CHAR_LIMIT;
 		int rowLimit = ImportFileConstants.XLS_ROW_LIMIT; // 65536: limit xls row number.
 		boolean isInitedColumnTitles = false;

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
@@ -145,7 +145,7 @@ public class ExportToXlsxHandler extends
 
 		try {
 			conn = getConnection();
-			String sql = getSelectSQL(tableName);
+			String sql = QueryUtil.getSelectSQL(conn, tableName); 
 			isPaginating = isPagination(whereCondition, sql, whereCondition);
 			int exportedCount = 0;
 			while (hasNextPage) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
@@ -105,6 +105,11 @@ public class ExportToXlsxHandler extends
 		if (StringUtil.isEmpty(tableName)) {
 			return;
 		}
+		
+		long totalRecord = exportConfig.getTotalCount(tableName);
+		if (totalRecord == 0) {
+			return;
+		}
 
 		int rowLimit = ImportFileConstants.XLSX_ROW_LIMIT; // 1048576: limit xlsx row number.
 		int columnLimit = ImportFileConstants.XLSX_COLUMN_LIMIT; // 16384: limit xlsx column number.
@@ -112,10 +117,6 @@ public class ExportToXlsxHandler extends
 
 		boolean hasNextPage = true;
 		long beginIndex = 1;
-		long totalRecord = exportConfig.getTotalCount(tableName);
-		if (totalRecord == 0) {
-			return;
-		}
 		
 		String whereCondition = exportConfig.getWhereCondition(tableName);
 

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
@@ -113,6 +113,10 @@ public class ExportToXlsxHandler extends
 		boolean hasNextPage = true;
 		long beginIndex = 1;
 		long totalRecord = exportConfig.getTotalCount(tableName);
+		if (totalRecord == 0) {
+			return;
+		}
+		
 		String whereCondition = exportConfig.getWhereCondition(tableName);
 
 		XlsxWriterHelper xlsxWriterhelper = new XlsxWriterHelper();

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
@@ -102,6 +102,10 @@ public class ExprotToOBSHandler extends
 				}
 
 				if (exportConfig.isExportData()) { //data
+					long totalRecord = exportConfig.getTotalCount(tableName);
+					if (totalRecord == 0) {
+						return;
+					}
 					String path = exportConfig.getDataFilePath(tableName);
 					BufferedWriter fs = null;
 					Connection conn = null;
@@ -115,17 +119,7 @@ public class ExprotToOBSHandler extends
 							exportDataEventHandler.handleEvent(new ExportDataBeginOneTableEvent(
 									path));
 
-							List<String> tableColumnList = exportConfig.getColumnNameList(tableName);
-							StringBuffer columns = new StringBuffer();
-							int size = tableColumnList.size();
-							for (int i = 0; i < tableColumnList.size(); i++) {
-								columns.append(QuerySyntax.escapeKeyword(tableColumnList.get(i)));
-								if (i != size - 1) {
-									columns.append(',');
-								}
-							}
-							String sql = "SELECT " + columns + " FROM "
-									+ QuerySyntax.escapeKeyword(tableName) + " ";
+							String sql = getSelectSQL(tableName);
 							String whereCondition = exportConfig.getWhereCondition(tableName);
 							if (whereCondition != null) {
 								sql += whereCondition;

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
@@ -119,7 +119,7 @@ public class ExprotToOBSHandler extends
 							exportDataEventHandler.handleEvent(new ExportDataBeginOneTableEvent(
 									path));
 
-							String sql = getSelectSQL(tableName);
+							String sql = QueryUtil.getSelectSQL(conn, tableName);
 
 							// [TOOLS-2425]Support shard broker
 							sql = DatabaseInfo.wrapShardQuery(dbInfo, sql);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
@@ -120,10 +120,6 @@ public class ExprotToOBSHandler extends
 									path));
 
 							String sql = getSelectSQL(tableName);
-							String whereCondition = exportConfig.getWhereCondition(tableName);
-							if (whereCondition != null) {
-								sql += whereCondition;
-							}
 
 							// [TOOLS-2425]Support shard broker
 							sql = DatabaseInfo.wrapShardQuery(dbInfo, sql);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
@@ -102,7 +102,7 @@ public class ExprotToSqlHandler extends
 			conn = getConnection();
 			fs = FileUtil.getBufferedWriter(exportConfig.getDataFilePath(tableName),
 					exportConfig.getFileCharset());
-			String sql = getSelectSQL(tableName);
+			String sql = QueryUtil.getSelectSQL(conn, tableName); 
 			isPaginating = isPagination(tableName, sql, whereCondition);
 			while (hasNextPage) {
 				try {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
@@ -94,6 +94,10 @@ public class ExprotToSqlHandler extends
 		CUBRIDPreparedStatementProxy pStmt = null;
 		CUBRIDResultSetProxy rs = null;
 
+		if (totalRecord == 0) {
+			return;
+		}
+		
 		try {
 			conn = getConnection();
 			fs = FileUtil.getBufferedWriter(exportConfig.getDataFilePath(tableName),

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
@@ -83,21 +83,21 @@ public class ExprotToSqlHandler extends
 		if (StringUtil.isEmpty(tableName)) {
 			return;
 		}
+		
+		long totalRecord = exportConfig.getTotalCount(tableName);
+		if (totalRecord == 0) {
+			return;
+		}
 
 		BufferedWriter fs = null;
 		String whereCondition = exportConfig.getWhereCondition(tableName);
 		boolean hasNextPage = true;
 		long beginIndex = 1;
 		int exportedCount = 0;
-		long totalRecord = exportConfig.getTotalCount(tableName);
 		Connection conn = null;
 		CUBRIDPreparedStatementProxy pStmt = null;
 		CUBRIDResultSetProxy rs = null;
 
-		if (totalRecord == 0) {
-			return;
-		}
-		
 		try {
 			conn = getConnection();
 			fs = FileUtil.getBufferedWriter(exportConfig.getDataFilePath(tableName),


### PR DESCRIPTION
This PR is related with #17.

Before I changed codes, Export function was very slow at database which have many tables and columns.
The reasons as below.
- All tables and columns were selected from database at the same time when "next" button was fired in "Choose the exporting type" page. But columns information is unnecessary in this page.
- When users clicked checkbox about "Select All" in "Configure the exporting options" then all columns were checked in for-loop. This is unnecessary too.

So, I refined about Export function like below.
- Deleted codes which is select all columns when "next" button was fired in "Choose the exporting type" page.
- Above logic is moved to "Confirm the exporting options" page and execute belong to only checked tables when "Finish" button was fired.
- Needless checking codes for subtrees are deleted in "Configure the exporting options"
- When data is not exist in table, querying to database for data will be skip.