### PR TITLE
EditHostDialog: remove a message and change another

### DIFF
--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/Messages.properties
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/Messages.properties
@@ -2,7 +2,7 @@
 titleAddHostDialog=Add Host
 titleConnectHostDialog=Edit Host
 msgAddHostDialog=Create a host.
-msgConnectHostDialog=Edit a host.
+msgConnectHostDialog=Modify the details of the selected host.
 btnConnectHost=Co&nnect
 btnAddHost=&Add
 btnBrowse=&Browse...

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/dialog/HostDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/dialog/HostDialog.java
@@ -332,7 +332,6 @@ public class HostDialog extends
 			setTitle(Messages.titleAddHostDialog);
 			setMessage(Messages.msgAddHostDialog);
 		} else {
-			setTitle(Messages.titleConnectHostDialog);
 			setMessage(Messages.msgConnectHostDialog);
 		}
 		return parentComp;


### PR DESCRIPTION
![edut](https://cloud.githubusercontent.com/assets/17722852/21425152/1911d252-c850-11e6-9a88-50cbd23758bd.png)
It is not desired to have 3 messages with the same string. I have removed one and changed the other ( the main title remains unchanged).