### PR TITLE
When running query which contains null data in LOB types, CM was hanged.

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/ResultSetDataCache.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/ResultSetDataCache.java
@@ -40,6 +40,8 @@ import org.slf4j.Logger;
 
 import com.cubrid.common.core.util.LogUtil;
 import com.cubrid.common.ui.query.control.ColumnInfo;
+import com.cubrid.jdbc.proxy.driver.CUBRIDBlobProxy;
+import com.cubrid.jdbc.proxy.driver.CUBRIDClobProxy;
 
 /**
  * 
@@ -89,16 +91,20 @@ public class ResultSetDataCache {
 				if(value instanceof Blob){
 					Blob blob = (Blob)value;
 					try {
-						blob.free();
-						blob =null;
+						if (blob != null && ((CUBRIDBlobProxy)blob).getProxyObj() != null) {
+							blob.free();
+							blob = null;
+						}
 					} catch (SQLException e) {
 						LOGGER.error(e.getMessage(), e);
 					}
 				}else if(value instanceof Clob){
 					Clob clob = (Clob)value;
 					try {
-						clob.free();
-						clob = null;
+						if (clob != null && ((CUBRIDClobProxy)clob).getProxyObj() != null) {
+							clob.free();
+							clob = null;
+						}
 					} catch (SQLException e) {
 						LOGGER.error(e.getMessage(), e);
 					}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
@@ -2558,15 +2558,15 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 		QueryUtil.freeQuery(stmt, rs);
 		stmt = null;
 		rs = null;
-		if (!allColumnList.isEmpty()) {
+		if (allColumnList != null && !allColumnList.isEmpty()) {
 			allColumnList.clear();
 			allColumnList = null;
 		}
-		if (!allDataList.isEmpty()) {
+		if (allDataList != null && !allDataList.isEmpty()) {
 			allDataList.clear();
 			allDataList = null;
 		}
-		if (!colComparatorMap.isEmpty()) {
+		if (colComparatorMap != null && !colComparatorMap.isEmpty()) {
 			colComparatorMap.clear();
 			colComparatorMap = null;
 		}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
@@ -2548,6 +2548,11 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 	 * dispose the object.
 	 */
 	public void dispose() {
+		disposeAll();
+		freeResultSetCache();
+	}
+	
+	private void disposeAll() {
 		try {
 			if (stmt != null) {
 				stmt.cancel();
@@ -2570,7 +2575,10 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 			colComparatorMap.clear();
 			colComparatorMap = null;
 		}
-		freeResultSetCache();
+	}
+	
+	public void initBeforeRunQuery() {
+		disposeAll();
 	}
 
 	public QueryInfo getQueryInfo() {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/editor/QueryEditorPart.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/editor/QueryEditorPart.java
@@ -1443,9 +1443,8 @@ public class QueryEditorPart extends
 		makeProgressBar();
 		runningCount.incrementAndGet();
 		
-		// [RND-5] performance improvement about executing query
 		if (result != null) {
-			result.dispose();
+			result.initBeforeRunQuery();
 		}
 
 		queryThread = new Thread(new QueryThread(queries, this, rowParameterList, con,


### PR DESCRIPTION
When users execute the query in CM then works to release the result objects - columns, datas, etc - using `dispose()` in `QueryEditorPart#runQuery()` for releasing resources.

Before I changed this codes, `dispose()` released caching data too.
But if caching data contains LOB types with `null` data cause `NullPointerException` and CM was hanged.

As above reason, when I was ran below query in CM at first time, result was returned.
However, next ran same query didn't return the result and hanged because caching data contains LOB tpyes with `null` data.

So, I add the inspecting logic about `NullPointerException` and separate `dispose()` method to `dispose()` and `initBeforeRunQuery()`.

### Test schemas
```sql
CREATE TABLE clob_test (code1 VARCHAR(10), code2 INT, code3 clob) ;

INSERT INTO clob_test VALUE ('clob_test',1,'cubrid_test'); 
INSERT INTO clob_test VALUE ('clob_test',2,'cubrid_test'); 
INSERT INTO clob_test VALUE ('clob_test',3,null); 
INSERT INTO clob_test VALUE ('clob_test',4,'cubrid_test'); 
INSERT INTO clob_test VALUE ('clob_test',5,'cubrid_test'); 
INSERT INTO clob_test VALUE ('clob_test',6,'cubrid_test'); 
```

### SQL
```sql
SELECT * FROM clob_test;
```