### PR TITLE
Wrong pk icon in the navigation tree

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
@@ -673,4 +673,28 @@ public final class QueryUtil {
 		
 		return columnList;
 	}
+	
+	public static List<String> getPrimaryKeys(Connection conn, String tableName) {
+		String sql = "SELECT key_attr_name " +
+				"FROM db_index_key " +
+				"WHERE class_name= ? AND index_name = 'pk'";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		List<String> pkColumns = new ArrayList<String>();
+		
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, tableName);
+			rs = pstmt.executeQuery();
+			while (rs.next()) {
+				pkColumns.add(rs.getString(1));
+			}
+		} catch (SQLException e) {
+			LOGGER.error(e.getLocalizedMessage());
+		} finally {
+			QueryUtil.freeQuery(pstmt, rs);
+		}
+		
+		return pkColumns;
+	}
 }

--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetUserClassColumnsTask.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetUserClassColumnsTask.java
@@ -84,13 +84,7 @@ public class GetUserClassColumnsTask extends
 				return columns;
 			}
 			columns = SchemaUtil.getTableColumn(databaseInfo, connection, tableName);
-
-			rs = getPrimaryKeys(tableName);
-			List<String> pkColumns = new ArrayList<String>();
-			while (rs.next()) {
-				pkColumns.add(rs.getString(1));
-			}
-			QueryUtil.freeQuery(pstmt, rs);
+			List<String> pkColumns = QueryUtil.getPrimaryKeys(connection, tableName);
 
 			for (TableColumn dbColumn : columns) {
 				String columnName = dbColumn.getColumnName();
@@ -111,17 +105,6 @@ public class GetUserClassColumnsTask extends
 			finish();
 		}
 		return columns;
-	}
-	
-	private ResultSet getPrimaryKeys(String tableName) throws SQLException {
-		String sql = "SELECT key_attr_name " +
-				"FROM db_index_key " +
-				"WHERE class_name= ? AND index_name = 'pk'";
-		pstmt = connection.prepareStatement(sql);
-		pstmt.setString(1, tableName);
-		rs = pstmt.executeQuery();
-		
-		return rs;
 	}
 
 	/**

--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetUserClassColumnsTask.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetUserClassColumnsTask.java
@@ -29,7 +29,6 @@
  */
 package com.cubrid.cubridmanager.core.cubrid.table.task;
 
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -61,7 +60,6 @@ public class GetUserClassColumnsTask extends
 		JDBCTask {
 	private static final Logger LOGGER = LogUtil.getLogger(GetUserClassColumnsTask.class);
 	private boolean isInTransation;
-	private PreparedStatement pstmt;
 
 	public GetUserClassColumnsTask(DatabaseInfo dbInfo) {
 		super("getUserClassColumns", dbInfo);


### PR DESCRIPTION
This PR is related with #15.

CUBRID version in 9.2.0 to 9.2.6, non pk column shown as pk column in host navigation tree.
That is engine's bug and I resolved it in CM.

Please check my PR.
Thank you.