### PR TITLE
Escaping quotation when executing COPYnPASTE operation on Insert and Update statement

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
@@ -697,4 +697,17 @@ public final class QueryUtil {
 		
 		return pkColumns;
 	}
+
+	public static boolean isStringDataType(String type) {
+		if (type.equals("CHAR") || type.equals("VARCHAR")
+				|| type.equals("CHARACTER") || type.equals("CHARACTER VARYING")
+				|| type.equals("STRING") || type.equals("NCHAR")
+				|| type.equals("NATIONAL CHARACTER")
+				|| type.equals("NATIONAL CHARACTER VARYING")
+				|| type.equals("NCHAR VARYING")) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 }

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1414,7 +1414,6 @@ public final class StringUtil {
 
 		int index = data.indexOf(oneQuote);
 		if (index == -1) {
-			wrapQutesAndAppendToData(quote);
 			return;
 		}
 

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1399,7 +1399,7 @@ public final class StringUtil {
 		}
 
 		replaceQuotes(quote);
-		wrapQutesAndAppendToData(quote);
+		wrapQuotesAndAppendToData(quote);
 
 		return data.toString();
 	}
@@ -1423,7 +1423,7 @@ public final class StringUtil {
 				&& (index = data.indexOf(oneQuote, index + 2)) != -1);
 	}
 
-	private static void wrapQutesAndAppendToData(char quote) {
+	private static void wrapQuotesAndAppendToData(char quote) {
 		data.insert(0, quote).insert(data.length(), quote);
 	}
 }

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1377,4 +1377,54 @@ public final class StringUtil {
 		
 		return order;
 	}
+
+	public static StringBuilder data = new StringBuilder();
+
+	/**
+	 * Escaping single quotation or double quotation.
+	 *
+	 * @param value
+	 * @return
+	 */
+	public static String escapeQuotes(String value) {
+		if (value == null) {
+			return value;
+		}
+		data.setLength(0);
+		char quote = value.charAt(0);
+
+		eliminateQuotesAndAppendToData(value);
+		if (data.length() == 0) {
+			return value;
+		}
+
+		replaceQuotes(quote);
+		wrapQutesAndAppendToData(quote);
+
+		return data.toString();
+	}
+
+	private static void eliminateQuotesAndAppendToData(String value) {
+		data.append(value.substring(1, value.length() - 1));
+	}
+
+	private static void replaceQuotes(char quote) {
+		String quotes = quote + "" + quote;
+		String oneQuote = Character.toString(quote);
+
+		int index = data.indexOf(oneQuote);
+		if (index == -1) {
+			wrapQutesAndAppendToData(quote);
+			return;
+		}
+
+		do {
+			data.insert(index, quote);
+		} while ((index = data.indexOf(quotes, index)) != -1
+				&& (index = data.indexOf(oneQuote, index + 2)) != -1);
+	}
+
+	private static void wrapQutesAndAppendToData(char quote) {
+		data.insert(0, quote).insert(data.length(), quote);
+	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
@@ -1437,8 +1437,11 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 				}
 
 				sql.append(colName);
-				values.append(getFormatedValue(colInfo, data));
-
+				if (QueryUtil.isStringDataType(colInfo.getType())) {
+					values.append(StringUtil.escapeQuotes(getFormatedValue(colInfo, data)));
+				} else {
+					values.append(getFormatedValue(colInfo, data));
+				}
 			}
 
 			sql.append(") VALUES (").append(values).append(");").append(StringUtil.NEWLINE);
@@ -1602,7 +1605,11 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 				}
 
 				sql.append(colName).append("=");
-				sql.append(getFormatedValue(colInfo, data));
+				if (QueryUtil.isStringDataType(colInfo.getType())) {
+					sql.append(StringUtil.escapeQuotes(getFormatedValue(colInfo, data)));
+				} else {
+					sql.append(getFormatedValue(colInfo, data));
+				}
 			}
 
 			sql.append(" WHERE ");

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
@@ -1612,7 +1612,6 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 				}
 			}
 
-			sql.append(" WHERE ");
 			int count = 0;
 
 			for (int i = 0; i < colCount; i++) {
@@ -1622,6 +1621,10 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 
 				if (!pkList.contains(colName)) {
 					continue;
+				}
+
+				if (i == 0) {
+					sql.append(" WHERE ");
 				}
 
 				if (count > 0) {


### PR DESCRIPTION
When users used `Selected rows> Copy INSERT to Clipboard` and `Selected rows> Copy UPDATE to Clipboard` didn't escaped single and double quotation.
So, copied Insert and Update sentence occured syntax error when string data contains single or double quotation.

After I changed this, that function good working when string data contains single and double quotations.

And there was one bug when using `Selected rows> Copy UPDATE to Clipboard` if target table haven't primary key.
I have fixed that too.
