### PR TITLE
Query result shows nothing when selecting clob contains empty string.

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
@@ -565,7 +565,9 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 			if (loadSize > 0) {
 				char[] buf = new char[loadSize];
 				int len = reader.read(buf);
-				buffer.append(buf, 0, len);
+				if (len != -1) {
+					buffer.append(buf, 0, len);
+				}
 				if (len >= loadSize && reader.read() != -1) {
 					cellValue.setHasLoadAll(false);
 				} else {


### PR DESCRIPTION
When selecting clob with empty string cause `ArrayIndexOutOfBounds` Exception in `QueryExecuter#loadClobData` because reading data from that clob returns -1.
