### PR TITLE
Fix typo and additional escaping quotes in "selected row > copy Insert & Update"

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1426,4 +1426,16 @@ public final class StringUtil {
 	private static void wrapQuotesAndAppendToData(char quote) {
 		data.insert(0, quote).insert(data.length(), quote);
 	}
+
+	public static char getWrappedQuote(String value) {
+		if (value != null) {
+			if (value.startsWith("'") && value.endsWith("'")) {
+				return '\'';
+			}
+			if (value.startsWith("\"") && value.endsWith("\"")) {
+				return '"';
+			}
+		}
+		return 0;
+	}
 }

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1387,7 +1387,7 @@ public final class StringUtil {
 	 * @return
 	 */
 	public static String escapeQuotes(String value) {
-		if (value == null) {
+		if (value == null || "NULL".equals(value)) {
 			return value;
 		}
 		data.setLength(0);

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1427,15 +1427,21 @@ public final class StringUtil {
 		data.insert(0, quote).insert(data.length(), quote);
 	}
 
-	public static char getWrappedQuote(String value) {
+	public static String getWrappedQuote(String value) {
 		if (value != null) {
 			if (value.startsWith("'") && value.endsWith("'")) {
-				return '\'';
+				return "'";
 			}
 			if (value.startsWith("\"") && value.endsWith("\"")) {
-				return '"';
+				return "\"";
 			}
 		}
-		return 0;
+		return "";
+	}
+
+	public static String insertQuotes(String quote, String data) {
+		data = data.substring(1, data.length() - 1);
+		data = quote + data + quote;
+		return "'" + data + "'";
 	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
@@ -1464,11 +1464,15 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 		if ("(NULL)".equals(data)) {
 			return nullValue;
 		} else {
+			String quote = StringUtil.getWrappedQuote(data);
 			try {
 				FormatDataResult formatResult = DBAttrTypeFormatter.formatForInput(
 						colInfo.getComleteType(), data, true, charset, false);
 				if (formatResult.isSuccess()
 						&& formatResult.getFormatedString() != null) {
+					if (!quote.equals("")) {
+						
+					}
 					return formatResult.getFormatedString();
 				}
 			} catch (Exception ex) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/QueryExecuter.java
@@ -1471,7 +1471,8 @@ public class QueryExecuter implements IShowMoreOperator{ // FIXME very complicat
 				if (formatResult.isSuccess()
 						&& formatResult.getFormatedString() != null) {
 					if (!quote.equals("")) {
-						
+						formatResult.setFormatedString(StringUtil.insertQuotes(
+								quote, formatResult.getFormatedString()));
 					}
 					return formatResult.getFormatedString();
 				}


### PR DESCRIPTION
This PR is related with #56.
You can see the fixed list as below.

### Fixed NULL typo.
  - When `NULL` value was contained in the selected row, value clause returned not `NULL` but `NULN`.
### Escaping quotes when that exists in the start and end.
  - If single or double quotations exist in the start and end position, before code was not escaping that.
  - Below image is result of select.
![result](https://cloud.githubusercontent.com/assets/16603187/22641054/85483e40-ec98-11e6-9863-24ee518504bb.png)

  -  Before I fixed this, copied result was look like below.
```sql
INSERT INTO quote (col1, col2) VALUES (1, 'abc');
INSERT INTO quote (col1, col2) VALUES (2, 'defg');
```
  - After I fixed, copied result was look like below.
```sql
INSERT INTO quote (col1, col2) VALUES (1, '''abc''');
INSERT INTO quote (col1, col2) VALUES (2, '"defg"');
```

Please check my PR. Thank you. 