### PR TITLE
Fixed invalid unit in Server Parameter

### DIFF
--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/common/control/PageSizeChoiceComposite.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/common/control/PageSizeChoiceComposite.java
@@ -278,7 +278,7 @@ public class PageSizeChoiceComposite {
 	public void setUnitOfSize(String str) {
 		boolean isItem = false;
 		for (int i = 0; i < unitItems.length; i++) {
-			if (unitItems[i].equalsIgnoreCase(str)) {
+			if (unitItems[i].substring(0, 1).equalsIgnoreCase(str)) {
 				unitCombo.select(i);
 				isItem = true;
 				break;


### PR DESCRIPTION
When I changed `data_buffer_size` to 1G and I have confirmed on CM, that parameter's unit size shows invalid unit to me.

- Checking `data_buffer_size`'s value in CSQL
![combo_csql](https://cloud.githubusercontent.com/assets/16603187/24027913/516f7766-0b0e-11e7-9e36-4197192ae392.png)

- Invalid unit displayed in CM (not GB but MB)
![combo_before](https://cloud.githubusercontent.com/assets/16603187/24027915/561313fe-0b0e-11e7-97f5-7cbc21a015c6.png)

So, I fixed that in `PageSizeChoiceComposite#setUnitOfSize`.
![combo_after](https://cloud.githubusercontent.com/assets/16603187/24027968/b603a9d6-0b0e-11e7-8640-ba8bea240b8b.png)

Please check my PR.
Thank you. 😄 