### PR TITLE
Fix the error of Edit Broker Config

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/control/BrokerConfigEditComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/control/BrokerConfigEditComposite.java
@@ -682,7 +682,7 @@ public class BrokerConfigEditComposite extends
 		Map<String, String> brokerMap = confListData.get(0);
 		for (int i = 1, len = confTableViewer.getTable().getColumnCount(); i < len; i++) {
 			String brokerName = brokerMap.get(Integer.toString(i));
-			if (isNotBlank(brokerName)) {
+			if (!isNotBlank(brokerName)) {
 				return Messages.bind(Messages.cubridBrokerConfEditorErrMsg3, i);
 			}
 			if (nameList.contains(brokerName)) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/control/BrokerConfigEditComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/control/BrokerConfigEditComposite.java
@@ -682,7 +682,7 @@ public class BrokerConfigEditComposite extends
 		Map<String, String> brokerMap = confListData.get(0);
 		for (int i = 1, len = confTableViewer.getTable().getColumnCount(); i < len; i++) {
 			String brokerName = brokerMap.get(Integer.toString(i));
-			if (!isNotBlank(brokerName)) {
+			if (isBlank(brokerName)) {
 				return Messages.bind(Messages.cubridBrokerConfEditorErrMsg3, i);
 			}
 			if (nameList.contains(brokerName)) {


### PR DESCRIPTION
When users change the broker's configuration in CM but that was not working.

## Reproduce step
1. Connect host
2. Right click the host -> Configure Parameter -> Edit Broker Config
3. Click the save button

## Error result
![error_1](https://cloud.githubusercontent.com/assets/16603187/25164706/9e3fba92-250d-11e7-9ac0-e100f3de03c1.png)

`validate()` method returned error dialog when broker's name is not blank. 
~~So, I just added the exclamation mark to the front of `isNotBlank()` in the `validate()`.~~
So, I just changed the method from `isNotBlank()` to `isBlank()` in the `validate()`.

![nice_1](https://cloud.githubusercontent.com/assets/16603187/25165061/758402fa-250f-11e7-9833-c2059de5a7a0.png)
![nice_2](https://cloud.githubusercontent.com/assets/16603187/25165067/7902fe86-250f-11e7-8771-69ca43f23ffe.png)


Please check my PR. Thank you. :smile:
