### PR TITLE
Table and Column's upper case issue in _cub_schema_comments

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/schemacomment/SchemaCommentHandler.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/schemacomment/SchemaCommentHandler.java
@@ -204,9 +204,9 @@ public class SchemaCommentHandler {
 
 	public static Map<String, SchemaComment> loadTableDescriptions(IDatabaseSpec dbSpec, Connection conn) 
 			throws SQLException {
-		String sql = "SELECT table_name, column_name, description"
+		String sql = "SELECT LOWER(table_name) as table_name, LOWER(column_name) as column_name, description"
 				+ " FROM " + ConstantsUtil.SCHEMA_DESCRIPTION_TABLE
-				+ " WHERE table_name LIKE '%' AND column_name = '*'";
+				+ " WHERE LOWER(table_name) LIKE '%' AND column_name = '*'";
 
 		// [TOOLS-2425]Support shard broker
 		if (dbSpec.isShard()) {
@@ -238,9 +238,9 @@ public class SchemaCommentHandler {
 	public static Map<String, SchemaComment> loadDescription(IDatabaseSpec dbSpec, 
 			Connection conn, String tableName) throws SQLException {
 		String pureTableName = tableName.replace("\"", "");
-		String sql = "SELECT table_name, column_name, description"
+		String sql = "SELECT LOWER(table_name) as table_name, LOWER(column_name) as column_name, description"
 				+ " FROM " + ConstantsUtil.SCHEMA_DESCRIPTION_TABLE
-				+ " WHERE table_name='" + pureTableName + "'";
+				+ " WHERE LOWER(table_name)='" + pureTableName.toLowerCase() + "'";
 
 		// [TOOLS-2425]Support shard broker
 		if (dbSpec.isShard()) {

--- a/com.cubrid.common.core/src/com/cubrid/common/core/schemacomment/SchemaCommentHandler.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/schemacomment/SchemaCommentHandler.java
@@ -281,7 +281,7 @@ public class SchemaCommentHandler {
 		sql = "UPDATE " + ConstantsUtil.SCHEMA_DESCRIPTION_TABLE
 				+ " SET description=?, last_updated=CURRENT_TIMESTAMP,"
 				+ " last_updated_user=CURRENT_USER"
-				+ " WHERE table_name=? AND column_name=?";
+				+ " WHERE LOWER(table_name)=? AND LOWER(column_name)=?";
 
 		// [TOOLS-2425]Support shard broker
 		if (dbSpec.isShard()) {
@@ -292,8 +292,8 @@ public class SchemaCommentHandler {
 			int i = 1;
 			stmt = conn.prepareStatement(sql);
 			stmt.setString(i++, description);
-			stmt.setString(i++, pureTableName);
-			stmt.setString(i++, pureColumnName);
+			stmt.setString(i++, pureTableName.toLowerCase());
+			stmt.setString(i++, pureColumnName.toLowerCase());
 			stmt.executeUpdate();
 			QueryUtil.commit(conn);
 		} catch (SQLException e) {
@@ -309,7 +309,7 @@ public class SchemaCommentHandler {
 			String tableName) throws SQLException {
 		String pureTableName = tableName.replace("\"", "");
 		String sql = "DELETE FROM " + ConstantsUtil.SCHEMA_DESCRIPTION_TABLE
-				+ " WHERE table_name='" + pureTableName + "'";
+				+ " WHERE LOWER(table_name)='" + pureTableName.toLowerCase() + "'";
 
 		// [TOOLS-2425]Support shard broker
 		if (dbSpec.isShard()) {
@@ -427,10 +427,10 @@ public class SchemaCommentHandler {
 		sqlSB.append(ConstantsUtil.SCHEMA_DESCRIPTION_TABLE );
 		sqlSB.append(" SET description = '");
 		sqlSB.append(desc);
-		sqlSB.append("', last_updated = CURRENT_TIMESTAMP, last_updated_user = CURRENT_USER WHERE table_name = '");
-		sqlSB.append(pureTableName);
-		sqlSB.append("' AND column_name = '");
-		sqlSB.append(pureColumnName);
+		sqlSB.append("', last_updated = CURRENT_TIMESTAMP, last_updated_user = CURRENT_USER WHERE LOWER(table_name) = '");
+		sqlSB.append(pureTableName.toLowerCase());
+		sqlSB.append("' AND LOWER(column_name) = '");
+		sqlSB.append(pureColumnName.toLowerCase());
 		sqlSB.append("';");
 		return sqlSB.toString();
 	}


### PR DESCRIPTION
CM's comments function couldn't found name of tables and columns when user inserted data to the `_cub_schema_comments` as manually using upper case.

## Reproduce step
1. Install the comments function
2. Creating test table
```sql
CREATE TABLE test (col1 INT, col2 DATETIME);
```
3. Insert data to the `_cub_schema_comments` as manually using upper case
```sql
INSERT INTO _cub_schema_comments VALUES('TEST', 'COL1', 'this is description', SYSDATETIME, CURRENT_USER);
```
4. Open the `edit table...` and see the opened window.

## Result
You can't see any comments - Table memo and Column memo - like below image. 

![result1](https://cloud.githubusercontent.com/assets/16603187/25214673/7acc0130-25d3-11e7-829b-ffed75c6c57a.png)



So, I changed `SELECT` and `UPDATE` queries using `LOWER()` and `toLowerCase()`.

Please check my PR. Thank  you. :smile: