### PR TITLE
display the output of 'SHOW' command in Table format

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/CubridUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/CubridUtil.java
@@ -122,25 +122,4 @@ public class CubridUtil {
 			QueryUtil.freeQuery(stmt);
 		}
 	}
-	
-	/**
-	 * Judge the sql is command
-	 * @param sql
-	 * @return
-	 */
-	public static boolean isCommand(String sql) {
-		if (!StringUtil.isEmpty(sql)) {
-			if (sql.trim().endsWith(";")) {
-				sql = sql.trim().substring(0, sql.trim().length() - 1);
-			}
-
-			String[] wordArray = sql.split("\\s|\\r|\\n|\\t");
-			if (wordArray.length > 0) {
-				if ("SHOW".equalsIgnoreCase(wordArray[0])
-						|| "SET".equalsIgnoreCase(wordArray[0]))
-					return true;
-			}
-		}
-		return false;
-	}
 }


### PR DESCRIPTION
When I executed about `SHOW` statement in CM that result was displayed in not `Table` but `StyledText`.

![img1](https://cloud.githubusercontent.com/assets/16603187/25979258/4882f022-3702-11e7-917d-855b9a8acca2.png)

That result in the above image is hard to understand what means about values because there is no names or informations about columns.

But you can display that result on the `Table` without changing codes just adding `--` above your sql. It looks like a bug!

![img2](https://cloud.githubusercontent.com/assets/16603187/25979297/85257112-3702-11e7-9bfd-90d06df3ca0e.png)

I found problem in constructor of `QueryExecutor` when   checking sql is command or not using `isCommand = CubridUtil.isCommand(orignQuery);`.

In `isCommand()`, `SHOW` statement is processed as command like below.
```java
String[] wordArray = sql.split("\\s|\\r|\\n|\\t");
if (wordArray.length > 0) {
	if ("SHOW".equalsIgnoreCase(wordArray[0]) || "SET".equalsIgnoreCase(wordArray[0]))
		return true;
}
```

I think this is not good to users who want to execute `SHOW` statement because that result looks bad.
Besides, `isCommand` is useless for `SET` because that never returns any `ResultSet` and don't have any displaying result in `Table` when it was executed.

As a result, I deleted all about `isCommand` logics in both `QueryExecutor` and `CubridUtil`.

Please check my PR.
Thank you. 😄 