### PR TITLE
Fix testcases's error about comment of SP

### DIFF
--- a/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/sp/model/SPArgsInfoTest.java
+++ b/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/sp/model/SPArgsInfoTest.java
@@ -55,7 +55,7 @@ public class SPArgsInfoTest extends
 		SPArgsInfo spArgsInfoNoArg = new SPArgsInfo();
 		assertNotNull(spArgsInfoNoArg);
 		SPArgsInfo spArgsInfo = new SPArgsInfo(spName, argName, index,
-				dataType, spArgsType);
+				dataType, spArgsType, null);
 		assertNotNull(spArgsInfo);
 
 		//test 	getters and setters	

--- a/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/sp/model/SPInfoTest.java
+++ b/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/sp/model/SPInfoTest.java
@@ -61,7 +61,7 @@ public class SPInfoTest extends
 		SPInfo sPInfo1 = new SPInfo(spName);
 		assertNotNull(sPInfo1);
 		SPInfo sPInfo = new SPInfo(spName, spType, returnType, language, owner,
-				target);
+				target, null);
 		assertNotNull(sPInfo);
 
 		//test 	getters and setters	

--- a/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/sp/model/SpModelTest.java
+++ b/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/sp/model/SpModelTest.java
@@ -28,7 +28,7 @@ public class SpModelTest extends
 		bean.setArgsInfoList(new ArrayList<SPArgsInfo>());
 		assertEquals(bean.getArgsInfoList().size(), 0);
 		bean.addSPArgsInfo(new SPArgsInfo("spName", "spName", -1, "spName",
-				SPArgsType.IN));
+				SPArgsType.IN, null));
 		bean.removeSPArgsInfo(new SPArgsInfo());
 	}
 


### PR DESCRIPTION
I didn't fixed some test cases for calling SPArgsInfo's `constructor` when I implemented SP's comment before.

So I fixed that in this PR. 

Please check my PR. Thank you. 😄 