### PR TITLE
Fix columns order as correctly when data is exported.

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
@@ -652,11 +652,11 @@ public final class QueryUtil {
 		return sql;
 	}
 	
-	public static List<String> getColumnList(Connection conn, String tableName) {
+	private static List<String> getColumnList(Connection conn, String tableName) {
 		List<String> columnList = new ArrayList<String>();
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
-		String sql = "SELECT attr_name FROM db_attribute WHERE class_name = ?";
+		String sql = "SELECT attr_name FROM db_attribute WHERE class_name = ? ORDER BY def_order";
 		
 		try {
 			pstmt = conn.prepareStatement(sql);


### PR DESCRIPTION
When users executed the `Export` feature in CM, the order of exported data was ordered in alphabetical.

So, the order of table's column and data was not matched and not working when users executed `Import` feature using exported data file.

Because above reason, `getSelectSQL()` was fixed.

Please check my PR. Thank you.