### PR TITLE
Fix binding error when using type of bit in import feature

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -41,6 +41,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
+import javax.xml.bind.DatatypeConverter;
+
 import org.slf4j.Logger;
 
 /**
@@ -1445,7 +1447,8 @@ public final class StringUtil {
 		return "'" + data + "'";
 	}
 
-	public static String parseBitToHex(String data) {
-		return (data).substring(2, data.length() - 1);
+	public static byte[] parseBitToBytes(String data) {
+		data = (data).substring(2, data.length() - 1);
+		return DatatypeConverter.parseHexBinary(data);
 	}
 }

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1444,4 +1444,8 @@ public final class StringUtil {
 		data = quote + data + quote;
 		return "'" + data + "'";
 	}
+
+	public static String parseBitToHex(String data) {
+		return (data).substring(2, data.length() - 1);
+	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/paramSetter/BitParamSetter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/paramSetter/BitParamSetter.java
@@ -37,8 +37,6 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import javax.xml.bind.DatatypeConverter;
-
 import com.cubrid.common.core.util.Closer;
 import com.cubrid.common.core.util.StringUtil;
 import com.cubrid.common.ui.cubrid.table.dialog.PstmtParameter;

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/paramSetter/BitParamSetter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/paramSetter/BitParamSetter.java
@@ -85,8 +85,7 @@ public class BitParamSetter extends DefaultParamSetter {
 			InputStream in = (InputStream) value;
 			bytesvalues = getBytesFromInputSteam(in);
 		} else if (value instanceof String) {	// bit or bit varying
-			value = StringUtil.parseBitToHex((String) value);
-			bytesvalues = DatatypeConverter.parseHexBinary(String.valueOf(value));
+			bytesvalues = StringUtil.parseBitToBytes((String) value);
 		} else {
 			bytesvalues = (byte[]) value;
 		}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/paramSetter/BitParamSetter.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/paramSetter/BitParamSetter.java
@@ -37,7 +37,10 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 
+import javax.xml.bind.DatatypeConverter;
+
 import com.cubrid.common.core.util.Closer;
+import com.cubrid.common.core.util.StringUtil;
 import com.cubrid.common.ui.cubrid.table.dialog.PstmtParameter;
 
 /**
@@ -81,6 +84,9 @@ public class BitParamSetter extends DefaultParamSetter {
 		} else if (value instanceof InputStream) {
 			InputStream in = (InputStream) value;
 			bytesvalues = getBytesFromInputSteam(in);
+		} else if (value instanceof String) {	// bit or bit varying
+			value = StringUtil.parseBitToHex((String) value);
+			bytesvalues = DatatypeConverter.parseHexBinary(String.valueOf(value));
 		} else {
 			bytesvalues = (byte[]) value;
 		}


### PR DESCRIPTION
When users used `BIT` or `BIT VARYING` types in feature of `Import` they received error about `java.lang.ClassCastException` in [CM](https://github.com/CUBRID/cubrid-manager).
That's reason is `BIT` or `BIT VARYING` were parsed as `String` then casted to `byte[]`.

- In [csql](http://cubrid.org/manual/en/10.0/csql.html), `BIT` or `BIT VARYING` data shown as `String` like below. (The third column: `attach`)
![csql](https://user-images.githubusercontent.com/16603187/26859382-4f375870-4b72-11e7-9f17-09da420b5a51.png)


- [CM](https://github.com/CUBRID/cubrid-manager) parse `BIT` or `BIT VARYING` as `String` like above data but there is no checking logic for `String` as below.
  - Codes of [CM](https://github.com/CUBRID/cubrid-manager): `BitParamSetter#handle()`
```java
		if (value instanceof Blob) {
			Blob blob = (Blob) value;
			InputStream in = blob.getBinaryStream();
			bytesvalues = getBytesFromInputSteam(in);

		} else if (value instanceof InputStream) {
			InputStream in = (InputStream) value;
			bytesvalues = getBytesFromInputSteam(in);
		} else {
			bytesvalues = (byte[]) value; // Exception occured here!
		}
```

We fixed this issue just add another condition for checking `String` then converting hexadecimal String to byte array.