### PR TITLE
Fix invalid error popup when connect the version of 10.1

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
@@ -55,6 +55,8 @@ public final class CompatibleUtil {
 	private static final String VER_9_2_0 = "9.2.0";
 	private static final String VER_9_3_0 = "9.3.0";
 	private static final String VER_10_0_0 = "10.0.0";
+	private static final String VER_10_1_0 = "10.1.0";
+
 	private CompatibleUtil() {
 	}
 
@@ -404,6 +406,10 @@ public final class CompatibleUtil {
 			return true;
 		}
 		if (compareVersion(serverInfo.getServerVersionKey(), VER_10_0_0, 2) == 0) {
+			return true;
+		}
+
+		if (compareVersion(serverInfo.getServerVersionKey(), VER_10_1_0, 2) == 0) {
 			return true;
 		}
 


### PR DESCRIPTION
When users connect with CUBRID 10.1 then CM pop up the below message dialog.
![screen shot 2017-06-13 at 11 15 27 am](https://user-images.githubusercontent.com/16603187/27110472-96c6543a-50e4-11e7-91dd-3943348e535b.png)

So, we fixed this for release the [CUBRID](https://github.com/CUBRID/cubrid) version of 10.1