### PR TITLE
Fix the bug about export all the results to a file

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/AbsExportDataHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/AbsExportDataHandler.java
@@ -48,7 +48,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -199,6 +198,16 @@ public abstract class AbsExportDataHandler {
 		if (!isHasBigValue) {
 			isHasBigValue = FieldHandlerUtils.isBitValue(columnType, precision);
 		}
+	}
+
+	protected String getSelectSQL(Connection conn, String name) {
+		String sql = null;
+		if (exportConfig.getSQL(name) != null) {
+			sql = exportConfig.getSQL(name);
+		} else {
+			sql = QueryUtil.getSelectSQL(conn, name);
+		}
+		return sql;
 	}
 
 	protected Connection getConnection() throws SQLException { // FIXME move this logic to core module

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportLoadDBHandler.java
@@ -150,7 +150,7 @@ public class ExportLoadDBHandler extends
 				boolean hasNextPage = true;
 				int exportedCount = 0;
 				long beginIndex = 1;
-				String sql = QueryUtil.getSelectSQL(conn, tableName); 
+				String sql = getSelectSQL(conn, tableName);
 				isPaginating = isPagination(tableName, sql, whereCondition);
 				boolean isExportedColumnTitles = false;
 				while (hasNextPage) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToTxtHandler.java
@@ -121,7 +121,7 @@ public class ExportToTxtHandler extends
 			conn = getConnection();
 			fs = FileUtil.getBufferedWriter(exportConfig.getDataFilePath(tableName),
 					exportConfig.getFileCharset());
-			String sql = QueryUtil.getSelectSQL(conn, tableName); 
+			String sql = getSelectSQL(conn, tableName);
 			isPaginating = isPagination(tableName, sql, whereCondition);
 			while (hasNextPage) {
 				try {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsHandler.java
@@ -130,7 +130,7 @@ public class ExportToXlsHandler extends
 			WritableSheet sheet = workbook.createSheet("Sheet " + sheetNum, sheetNum);
 			sheetNum++;
 			int exportedCount = 0;
-			String sql = QueryUtil.getSelectSQL(conn, tableName);
+			String sql = getSelectSQL(conn, tableName);
 			isPaginating = isPagination(whereCondition, sql, whereCondition);
 			while (hasNextPage) {
 				try {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExportToXlsxHandler.java
@@ -146,7 +146,7 @@ public class ExportToXlsxHandler extends
 
 		try {
 			conn = getConnection();
-			String sql = QueryUtil.getSelectSQL(conn, tableName); 
+			String sql = getSelectSQL(conn, tableName);
 			isPaginating = isPagination(whereCondition, sql, whereCondition);
 			int exportedCount = 0;
 			while (hasNextPage) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToOBSHandler.java
@@ -119,7 +119,7 @@ public class ExprotToOBSHandler extends
 							exportDataEventHandler.handleEvent(new ExportDataBeginOneTableEvent(
 									path));
 
-							String sql = QueryUtil.getSelectSQL(conn, tableName);
+							String sql = getSelectSQL(conn, tableName);
 
 							// [TOOLS-2425]Support shard broker
 							sql = DatabaseInfo.wrapShardQuery(dbInfo, sql);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/export/handler/ExprotToSqlHandler.java
@@ -102,7 +102,7 @@ public class ExprotToSqlHandler extends
 			conn = getConnection();
 			fs = FileUtil.getBufferedWriter(exportConfig.getDataFilePath(tableName),
 					exportConfig.getFileCharset());
-			String sql = QueryUtil.getSelectSQL(conn, tableName); 
+			String sql = getSelectSQL(conn, tableName);
 			isPaginating = isPagination(tableName, sql, whereCondition);
 			while (hasNextPage) {
 				try {


### PR DESCRIPTION
This issue is related with PR of #43.

```java
if (exportConfig.getSQL(name) != null) {
	sql = exportConfig.getSQL(name);
}
```
The above code will generate the SQL to be used in the export.
However, the above code was deleted from # 43 PR, and SQL could not be created normally, resulting in a syntax error.
So, We fixed that issue this PR.