### PR TITLE
BOM processing in the import feature

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/StringUtil.java
@@ -1451,4 +1451,15 @@ public final class StringUtil {
 		data = (data).substring(2, data.length() - 1);
 		return DatatypeConverter.parseHexBinary(data);
 	}
+
+	public static String removeBOM(String data, String charset) {
+		if ("UTF-8".equals(charset)) {
+			String BOM = "\uFEFF";
+			if (data.startsWith(BOM)) {
+				return data.replace(BOM, "");
+			}
+		}
+
+		return data;
+	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/progress/AbsImportRunnable.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/progress/AbsImportRunnable.java
@@ -475,7 +475,8 @@ public abstract class AbsImportRunnable implements
 				String content = null;
 				String pattern = null;
 				if (columnArray.length > column) {
-					content = columnArray[column];
+					content = currentRow != 0 ? columnArray[column] :
+						StringUtil.removeBOM(columnArray[column], importConfig.getFilesCharset());
 				}
 
 				if (columnPattern != null && columnPattern.length > column) {


### PR DESCRIPTION
If there is a [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) in UTF-8 files, the import feature will not output the first data correctly.

- Data example (csv format)
```
1234567890
2345678901
3456789012
4567890123
5678901234
```
- Result
![before_fixed](https://user-images.githubusercontent.com/16603187/27850240-31c928a4-618e-11e7-851b-7436804c1c6a.png)

So, when using UTF-8 files, we added code to remove the [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) if there is.
