### PR TITLE
Corrected the NullPointerException when right-clicking a table list

### DIFF
--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetSchemaTask.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetSchemaTask.java
@@ -770,9 +770,11 @@ public class GetSchemaTask extends JDBCTask {
 						attr.setCollation(collation);
 					}
 
-					SchemaComment schemaComment = comments.get(tableName + "*" + attrName);
-					if (schemaComment != null) {
-						attr.setDescription(schemaComment.getDescription());
+					if (comments != null) {
+						SchemaComment schemaComment = comments.get(tableName + "*" + attrName);
+						if (schemaComment != null) {
+							attr.setDescription(schemaComment.getDescription());
+						}
 					}
 
 					if ("INSTANCE".equals(type)) { //INSTANCE


### PR DESCRIPTION
If the `_cub_schema_comments` table does not exist, right-clicking on the table list resulted the `NullPointerException`.
So we fixed this.