### PR TITLE
Can't connect the CM when using 8.x engine

### DIFF
--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/ServerVersion.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/ServerVersion.java
@@ -1,6 +1,7 @@
 package com.cubrid.cubridmanager.core.common.model;
 
-import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ServerVersion {
 	private int majorVersion, minorVersion;
@@ -9,7 +10,6 @@ public class ServerVersion {
 	public ServerVersion() {
 		this(-1, -1);
 	}
-	
 
 	public ServerVersion(int majorVersion, int minorVersion) {
 		this.majorVersion = majorVersion;
@@ -18,18 +18,20 @@ public class ServerVersion {
 	
 	public void setVersion(String fullVersion) {
 		serverVersion = fullVersion;
-		StringTokenizer st = new StringTokenizer(fullVersion);
-		st.nextToken();
-		String versionNo = st.nextToken();
+		String regex = "\\d*\\.\\d*\\.\\d*\\.[\\d-a-zA-Z]*";
+		Matcher matcher = Pattern.compile(regex)
+				.matcher(fullVersion);
 		
-		majorVersion = Integer.parseInt(versionNo.substring(0, versionNo.indexOf('.')));
-		minorVersion = Integer.parseInt(versionNo.substring(versionNo.indexOf('.')+1));
+		if (matcher.find()) {
+			String[] versions = matcher.group().split("\\.");
+			majorVersion = Integer.parseInt(versions[0]);
+			minorVersion = Integer.parseInt(versions[1]);
+		}
 	}
 	
 	public boolean isSmallerThan(int majorVersion, int minorVersion) {
 		return (majorVersion == this.majorVersion) ? (this.minorVersion < minorVersion) :
 													 (this.majorVersion < majorVersion);
-						
 	}
 	
 	public boolean isSmallerThan(ServerVersion serverVersion) {


### PR DESCRIPTION
Displaying engine's version information is not same at each engines.
```
CUBRID 2008 R4.4 (8.4.4.17007) (64bit release build for linux_gnu) (Dec 26 2016 14:54:31)
CUBRID 9.3 (9.3.6.0002) (64bit release build for linux_gnu) (Feb 29 2016 19:36:35)
```
Because of above reason, separating version string using  `StringTokenizer` makes error when using engine of 8.x version.

So, we changed that to Regular Expression.

Please check my PR.
Thank you. 😄 