### PR TITLE
[TOOLS-4274] CUBRID Manager version during setup is incorrect

### DIFF
--- a/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager.nsi
+++ b/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager.nsi
@@ -23,7 +23,7 @@
 ;!define OUTFILE_PATH '.'
 
 !define PRODUCT_NAME 'CUBRID Manager'
-!define PRODUCT_VERSION '9.3.1'
+!define PRODUCT_VERSION '10.1.0'
 !define PRODUCT_EXE_NAME 'cubridmanager'
 
 !define SHORTCUT_NAME '${PRODUCT_NAME}'

--- a/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager_with_jre.nsi
+++ b/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager_with_jre.nsi
@@ -23,7 +23,7 @@
 ;!define OUTFILE_PATH '.'
 
 !define PRODUCT_NAME 'CUBRID Manager'
-!define PRODUCT_VERSION '2013'
+!define PRODUCT_VERSION '2017'
 !define PRODUCT_EXE_NAME 'cubridmanager'
 
 !define SHORTCUT_NAME '${PRODUCT_NAME}'

--- a/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager_x64.nsi
+++ b/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager_x64.nsi
@@ -22,7 +22,7 @@
 ;!define OUTFILE_PATH '.'
 
 !define PRODUCT_NAME 'CUBRID Manager'
-!define PRODUCT_VERSION '9.3.1'
+!define PRODUCT_VERSION '10.1.0'
 !define PRODUCT_EXE_NAME 'cubridmanager'
 !define INSTALLER_ARCH 'x64'
 

--- a/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager_x64_with_jre.nsi
+++ b/com.cubrid.cubridmanager.build/installer/win/CUBRIDManager_x64_with_jre.nsi
@@ -22,7 +22,7 @@
 ;!define OUTFILE_PATH '.'
 
 !define PRODUCT_NAME 'CUBRID Manager'
-!define PRODUCT_VERSION '2013'
+!define PRODUCT_VERSION '2017'
 !define PRODUCT_EXE_NAME 'cubridmanager'
 !define INSTALLER_ARCH 'x64'
 


### PR DESCRIPTION
Please refer to [TOOLS-4274](http://jira.cubrid.org/browse/TOOLS-4274).