### PR TITLE
[TOOLS-4280] Window for typing PASSWORD is too small and hard to key-in a password in DATABASE delete menu

### DIFF
--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/DeleteDatabaseConfirmDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/DeleteDatabaseConfirmDialog.java
@@ -116,7 +116,7 @@ public class DeleteDatabaseConfirmDialog extends
 	 */
 	protected void constrainShellSize() {
 		super.constrainShellSize();
-		getShell().setSize(300, 220);
+		getShell().setSize(500, 220);
 		CommonUITool.centerShell(getShell());
 		getShell().setText(Messages.titleDeleteDbConfirmDialog);
 


### PR DESCRIPTION
[TOOLS-4280] Change the width of 'DBA Confirm Dialog' to key-in a password easily