### PR TITLE
[TOOLS-4290] Fixed for cast problem in JDK6

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/progress/LoadTableColumnsProgress.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/progress/LoadTableColumnsProgress.java
@@ -90,6 +90,6 @@ public class LoadTableColumnsProgress extends LoadTableProgress {
 
 	@Override
 	protected void setCount(TableDetailInfo tablesDetailInfo, Object count) {
-		tablesDetailInfo.setColumnsCount((int) count);
+		tablesDetailInfo.setColumnsCount(Integer.parseInt(count.toString()));
 	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/progress/LoadTableRecordCountsProgress.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/progress/LoadTableRecordCountsProgress.java
@@ -85,6 +85,6 @@ public class LoadTableRecordCountsProgress extends LoadTableProgress {
 
 	@Override
 	protected void setCount(TableDetailInfo tablesDetailInfo, Object count) {
-		tablesDetailInfo.setRecordsCount((int) count);
+		tablesDetailInfo.setRecordsCount(Integer.parseInt(count.toString()));
 	}
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/progress/LoadTableRecordSizeProgress.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/progress/LoadTableRecordSizeProgress.java
@@ -152,7 +152,7 @@ public class LoadTableRecordSizeProgress extends LoadTableProgress {
 	protected void setCount(TableDetailInfo tablesDetailInfo, Object count) {
 		Object[] values = (Object[]) count;
 		tablesDetailInfo.setRecordsSize((BigDecimal) values[RECORD_SIZE]);
-		tablesDetailInfo.setHasUnCountColumnSize((boolean) values[UNCOUNT_COLUMN_SIZE]);
+		tablesDetailInfo.setHasUnCountColumnSize(Boolean.parseBoolean((values[UNCOUNT_COLUMN_SIZE]).toString()));
 	}
 
 }


### PR DESCRIPTION
In JDK version 6, the build fails because the Object is not cast to primitive type by force.

So we changed the casting of the primitive type like int, boolean.

Example of casting failure in JDK 6.
```Java
public class Test {
	public static void main(String[] args) {
		Object io = 10;
		int i = (int) io;
	}
}

```

```
[hun-a@localhost ~]$ javac -version
javac 1.6.0_45
[hun-a@localhost ~]$ javac Test.java
Test.java:4: inconvertible types
found   : java.lang.Object
required: int
		int i = (int) io;
		              ^
1 error
```