### PR TITLE
[CM] 'TABLE Comment is not properly shown in 'Edit Table...' sub-menu when a table name belong to CUBRID Keywords.

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/schemacomment/SchemaCommentHandler.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/schemacomment/SchemaCommentHandler.java
@@ -243,8 +243,8 @@ public class SchemaCommentHandler {
 					+ "SELECT class_name as table_name, attr_name as column_name, comment as description "
 					+ "FROM db_attribute %s";
 			if (StringUtil.isNotEmpty(tableName)) {
-				tableCondition = "AND class_name = '" + QuerySyntax.escapeKeyword(tableName) + "' ";
-				columnCondition = "WHERE class_name = '" + QuerySyntax.escapeKeyword(tableName) + "'";
+				tableCondition = "AND class_name = '" + tableName + "' ";
+				columnCondition = "WHERE class_name = '" + tableName + "'";
 			} else {
 				tableCondition = "AND comment is not null ";
 				columnCondition = "WHERE comment is not null";


### PR DESCRIPTION
Please, Refer to [TOOLS-4307](http://jira.cubrid.org/browse/TOOLS-4307)
* [TOOLS-4307] Change not to use QuerySyntax.escapeKeyword method