### PR TITLE
[TOOLS-4312] Change URL reference of CUBRID Tools from ftp.cubrid.org to cubrid.github.io

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/notice/control/NoticeDashboardPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/notice/control/NoticeDashboardPage.java
@@ -86,7 +86,7 @@ public class NoticeDashboardPage extends FormPage {
 
 	private static final Logger LOGGER = LogUtil.getLogger(NoticeDashboardPage.class);
 
-	private static final String rsssource = "http://ftp.cubrid.org/sites/inf/";
+	private static final String rsssource = "https://cubrid.github.io/";
 	private static String language = Platform.getNL();
 	static {
 		if (language.equals("ko_KR")) {


### PR DESCRIPTION
* Please, Refer to [TOOLS-4312](http://jira.cubrid.org/browse/TOOLS-4312)