### PR TITLE
[TOOLS-4317] [CM] If 'oracle_style_empty_string=yes' is added in cubrid.conf, Tables are not shown in the CM Navigator View

### DIFF
--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetAllClassListTask.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetAllClassListTask.java
@@ -104,10 +104,9 @@ public class GetAllClassListTask extends JDBCTask {
 				sql += " OR class_name='" + ConstantsUtil.CUNITOR_HA_TABLE + "'";
 			}
 			
-			sql += " AND class_name > '' ORDER BY class_name";
+			sql += " ORDER BY class_name";
 			
 			sql = databaseInfo.wrapShardQuery(sql);
-
 			boolean existSchemaCommentTable = false;
 			stmt = connection.createStatement();
 			rs = stmt.executeQuery(sql);


### PR DESCRIPTION
* Please, Refer to [TOOLS-4317](http://jira.cubrid.org/browse/TOOLS-4317)