### PR TITLE
[TOOLS-4332] [CUBRID Admin] Warning pop-up shows up even if an user uses right version of driver (10.2.1)

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
@@ -56,6 +56,7 @@ public final class CompatibleUtil {
 	private static final String VER_9_3_0 = "9.3.0";
 	private static final String VER_10_0_0 = "10.0.0";
 	private static final String VER_10_1_0 = "10.1.0";
+	private static final String VER_10_2_0 = "10.2.0";
 
 	private CompatibleUtil() {
 	}
@@ -408,8 +409,10 @@ public final class CompatibleUtil {
 		if (compareVersion(serverInfo.getServerVersionKey(), VER_10_0_0, 2) == 0) {
 			return true;
 		}
-
 		if (compareVersion(serverInfo.getServerVersionKey(), VER_10_1_0, 2) == 0) {
+			return true;
+		}
+		if (compareVersion(serverInfo.getServerVersionKey(), VER_10_2_0, 2) == 0) {
 			return true;
 		}
 


### PR DESCRIPTION
* Please, Refer to [TOOLS-4332](http://jira.cubrid.org/browse/TOOLS-4332)