### PR TITLE
[TOOLS-4358] compatible issue for Server Version 11.0.1 or more and CUBRID site connection error.

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
@@ -33,342 +33,342 @@ import com.cubrid.common.core.common.model.IDatabaseSpec;
 import com.cubrid.common.core.common.model.IServerSpec;
 
 /**
- * To make dbms tools have downward compatibility, this class provides functions
- * supported information in the versions.
+ * To make dbms tools have downward compatibility, this class provides functions supported
+ * information in the versions.
  *
  * @author SC13425
  * @version 1.0 - 2010-11-17 created by SC13425
  */
 public final class CompatibleUtil {
-	private static final String VER_8_2_0 = "8.2.0";
-	private static final String VER_8_2_1 = "8.2.1";
-	private static final String VER_8_2_2 = "8.2.2";
-	private static final String VER_8_3_0 = "8.3.0";
-	private static final String VER_8_3_1 = "8.3.1";
-	private static final String VER_8_4_0 = "8.4.0";
-	private static final String VER_8_4_1 = "8.4.1";
-	private static final String VER_8_4_3 = "8.4.3";
-	private static final String VER_8_4_4 = "8.4.4";
-	private static final String VER_8_4_9 = "8.4.9";
-	private static final String VER_9_0_0 = "9.0.0";
-	private static final String VER_9_1_0 = "9.1.0";
-	private static final String VER_9_2_0 = "9.2.0";
-	private static final String VER_9_3_0 = "9.3.0";
-	private static final String VER_10_0_0 = "10.0.0";
-	private static final String VER_10_1_0 = "10.1.0";
-	private static final String VER_10_2_0 = "10.2.0";
-	private static final String VER_10_2_1 = "10.2.1";
-	private static final String VER_11_0_0 = "11.0.0";
-	private static final String VER_11_0_1 = "11.0.1";
-	private static final String VER_11_2_0 = "11.2.0"; //From 11.2 version, the engine and jdbc versioning  are different.
+    private static final String VER_8_2_0 = "8.2.0";
+    private static final String VER_8_2_1 = "8.2.1";
+    private static final String VER_8_2_2 = "8.2.2";
+    private static final String VER_8_3_0 = "8.3.0";
+    private static final String VER_8_3_1 = "8.3.1";
+    private static final String VER_8_4_0 = "8.4.0";
+    private static final String VER_8_4_1 = "8.4.1";
+    private static final String VER_8_4_3 = "8.4.3";
+    private static final String VER_8_4_4 = "8.4.4";
+    private static final String VER_8_4_9 = "8.4.9";
+    private static final String VER_9_0_0 = "9.0.0";
+    private static final String VER_9_1_0 = "9.1.0";
+    private static final String VER_9_2_0 = "9.2.0";
+    private static final String VER_9_3_0 = "9.3.0";
+    private static final String VER_10_0_0 = "10.0.0";
+    private static final String VER_10_1_0 = "10.1.0";
+    private static final String VER_10_2_0 = "10.2.0";
+    private static final String VER_10_2_1 = "10.2.1";
+    private static final String VER_11_0_0 = "11.0.0";
+    private static final String VER_11_0_1 = "11.0.1";
+    private static final String VER_11_2_0 =
+            "11.2.0"; // From 11.2 version, the engine and jdbc versioning  are different.
 
-	private CompatibleUtil() {
-	}
+    private CompatibleUtil() {}
 
-	/**
-	 * Compare these two versions
-	 *
-	 * @param version1 the version string
-	 * @param version2 the version string
-	 * @return the value <code>0</code> if they are equal;<code>-1</code>
-	 *         version1 less than version2;<code>1</code> version1 greater than
-	 *         version2;<code>-2</code> the version string is not valid
-	 */
-	public static int compareVersion(String version1, String version2) {
-		return compareVersion(version1, version2, 4);
-	}
+    /**
+     * Compare these two versions
+     *
+     * @param version1 the version string
+     * @param version2 the version string
+     * @return the value <code>0</code> if they are equal;<code>-1</code> version1 less than
+     *     version2;<code>1</code> version1 greater than version2;<code>-2</code> the version string
+     *     is not valid
+     */
+    public static int compareVersion(String version1, String version2) {
+        return compareVersion(version1, version2, 4);
+    }
 
-	/**
-	 * Compare these two versions
-	 *
-	 * @param version1 the version string
-	 * @param version2 the version string
-	 * @param comparedLength the compared length
-	 * @return the value <code>0</code> if they are equal;<code>-1</code>
-	 *         version1 less than version2;<code>1</code> version1 greater than
-	 *         version2;<code>-2</code> the version string is not valid
-	 */
-	public static int compareVersion(String version1, String version2, int comparedLength) {
-		if (version1 == null || version2 == null) {
-			return -2;
-		}
+    /**
+     * Compare these two versions
+     *
+     * @param version1 the version string
+     * @param version2 the version string
+     * @param comparedLength the compared length
+     * @return the value <code>0</code> if they are equal;<code>-1</code> version1 less than
+     *     version2;<code>1</code> version1 greater than version2;<code>-2</code> the version string
+     *     is not valid
+     */
+    public static int compareVersion(String version1, String version2, int comparedLength) {
+        if (version1 == null || version2 == null) {
+            return -2;
+        }
 
-		String[] versionParts = version1.split("\\.");
-		String[] compareParts = version2.split("\\.");
-		if (compareParts.length < 3 || versionParts.length < 3) {
-			return -2;
-		}
+        String[] versionParts = version1.split("\\.");
+        String[] compareParts = version2.split("\\.");
+        if (compareParts.length < 3 || versionParts.length < 3) {
+            return -2;
+        }
 
-		int length = Math.min(compareParts.length, versionParts.length);
-		for (int i = 0; i < length && i < comparedLength; i++) {
-			if (!versionParts[i].trim().matches("\\d+")
-					|| !compareParts[i].trim().matches("\\d+")) {
-				return -2;
-			}
+        int length = Math.min(compareParts.length, versionParts.length);
+        for (int i = 0; i < length && i < comparedLength; i++) {
+            if (!versionParts[i].trim().matches("\\d+")
+                    || !compareParts[i].trim().matches("\\d+")) {
+                return -2;
+            }
 
-			int iVersionPart = Integer.parseInt(versionParts[i]);
-			int iComparePart = Integer.parseInt(compareParts[i]);
-			if (iVersionPart > iComparePart) {
-				return 1;
-			} else if (iVersionPart < iComparePart) {
-				return -1;
-			}
-		}
+            int iVersionPart = Integer.parseInt(versionParts[i]);
+            int iComparePart = Integer.parseInt(compareParts[i]);
+            if (iVersionPart > iComparePart) {
+                return 1;
+            } else if (iVersionPart < iComparePart) {
+                return -1;
+            }
+        }
 
-		return 0;
-	}
+        return 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.2.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.2.0 or higher
-	 */
-	public static boolean isAfter820(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_2_0) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.2.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.2.0 or higher
+     */
+    public static boolean isAfter820(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_2_0) >= 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.2.2
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.2.2 or higher
-	 */
-	public static boolean isAfter822(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_2_2) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.2.2
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.2.2 or higher
+     */
+    public static boolean isAfter822(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_2_2) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 8.2.2
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:8.2.2 or higher
-	 */
-	public static boolean isAfter822(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_8_2_2) >= 0;
-	}
+    /**
+     * Is the version of database after the 8.2.2
+     *
+     * @param database DatabaseInfo
+     * @return true:8.2.2 or higher
+     */
+    public static boolean isAfter822(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_8_2_2) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 8.3.0
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:8.3.0 or higher
-	 */
-	public static boolean isAfter830(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_8_3_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 8.3.0
+     *
+     * @param database DatabaseInfo
+     * @return true:8.3.0 or higher
+     */
+    public static boolean isAfter830(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_8_3_0) >= 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.3.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.3.0 or higher
-	 */
-	public static boolean isAfter830(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_3_0) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.3.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.3.0 or higher
+     */
+    public static boolean isAfter830(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_3_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 8.3.1
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:8.3.1 or higher
-	 */
-	public static boolean isAfter831(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_8_3_1) >= 0;
-	}
+    /**
+     * Is the version of database after the 8.3.1
+     *
+     * @param database DatabaseInfo
+     * @return true:8.3.1 or higher
+     */
+    public static boolean isAfter831(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_8_3_1) >= 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.3.1
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.3.1 or higher
-	 */
-	public static boolean isAfter831(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_3_1) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.3.1
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.3.1 or higher
+     */
+    public static boolean isAfter831(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_3_1) >= 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.4.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.4.0 or higher
-	 */
-	public static boolean isAfter840(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_0) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.4.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.4.0 or higher
+     */
+    public static boolean isAfter840(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 8.4.0
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:8.4.0 or higher
-	 */
-	public static boolean isAfter840(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_8_4_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 8.4.0
+     *
+     * @param database DatabaseInfo
+     * @return true:8.4.0 or higher
+     */
+    public static boolean isAfter840(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_8_4_0) >= 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.4.1
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.4.1 or higher
-	 */
-	public static boolean isAfter841(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_1) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.4.1
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.4.1 or higher
+     */
+    public static boolean isAfter841(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_1) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 8.4.1
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:8.4.1 or higher
-	 */
-	public static boolean isAfter841(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_8_4_1) >= 0;
-	}
+    /**
+     * Is the version of database after the 8.4.1
+     *
+     * @param database DatabaseInfo
+     * @return true:8.4.1 or higher
+     */
+    public static boolean isAfter841(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_8_4_1) >= 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.4.3
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.4.3 or higher
-	 */
-	public static boolean isAfter843(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_3) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.4.3
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.4.3 or higher
+     */
+    public static boolean isAfter843(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_3) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 8.4.3
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:8.4.3 or higher
-	 */
-	public static boolean isAfter843(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_8_4_3) >= 0;
-	}
+    /**
+     * Is the version of database after the 8.4.3
+     *
+     * @param database DatabaseInfo
+     * @return true:8.4.3 or higher
+     */
+    public static boolean isAfter843(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_8_4_3) >= 0;
+    }
 
-	/**
-	 * Is the version of cm server after the 8.4.4
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.4.4 or higher
-	 */
-	public static boolean isAfter844(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_4) >= 0;
-	}
+    /**
+     * Is the version of cm server after the 8.4.4
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.4.4 or higher
+     */
+    public static boolean isAfter844(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_4_4) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 8.4.4
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:8.4.4 or higher
-	 */
-	public static boolean isAfter844(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_8_4_4) >= 0;
-	}
+    /**
+     * Is the version of database after the 8.4.4
+     *
+     * @param database DatabaseInfo
+     * @return true:8.4.4 or higher
+     */
+    public static boolean isAfter844(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_8_4_4) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.0.0
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:9.0.0 or higher
-	 */
-	public static boolean isAfter900(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_9_0_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.0.0
+     *
+     * @param database DatabaseInfo
+     * @return true:9.0.0 or higher
+     */
+    public static boolean isAfter900(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_9_0_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.0.0
-	 *
-	 * @param serverInfo isAfter900
-	 * @return true:9.0.0 or higher
-	 */
-	public static boolean isAfter900(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_9_0_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.0.0
+     *
+     * @param serverInfo isAfter900
+     * @return true:9.0.0 or higher
+     */
+    public static boolean isAfter900(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_9_0_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.1.0
-	 *
-	 * @param serverInfo isAfter910
-	 * @return true:9.1.0 or higher
-	 */
-	public static boolean isAfter910(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_9_1_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.1.0
+     *
+     * @param serverInfo isAfter910
+     * @return true:9.1.0 or higher
+     */
+    public static boolean isAfter910(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_9_1_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.1.0
-	 *
-	 * @param database IDatabaseSpec
-	 * @return true:9.1.0 or higher
-	 */
-	public static boolean isAfter910(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_9_1_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.1.0
+     *
+     * @param database IDatabaseSpec
+     * @return true:9.1.0 or higher
+     */
+    public static boolean isAfter910(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_9_1_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.2.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:9.2.0 or higher
-	 */
-	public static boolean isAfter920(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_9_2_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.2.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true:9.2.0 or higher
+     */
+    public static boolean isAfter920(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_9_2_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.2.0
-	 *
-	 * @param database IDatabaseSpec
-	 * @return true:9.2.0 or higher
-	 */
-	public static boolean isAfter920(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_9_2_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.2.0
+     *
+     * @param database IDatabaseSpec
+     * @return true:9.2.0 or higher
+     */
+    public static boolean isAfter920(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_9_2_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.3.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:9.3.0 or higher
-	 */
-	public static boolean isAfter930(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_9_3_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.3.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true:9.3.0 or higher
+     */
+    public static boolean isAfter930(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_9_3_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 9.3.0
-	 *
-	 * @param database IDatabaseSpec
-	 * @return true:9.3.0 or higher
-	 */
-	public static boolean isAfter930(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_9_3_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 9.3.0
+     *
+     * @param database IDatabaseSpec
+     * @return true:9.3.0 or higher
+     */
+    public static boolean isAfter930(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_9_3_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 10.0.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:10.0.0 or higher
-	 */
-	public static boolean isAfter100(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_10_0_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 10.0.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true:10.0.0 or higher
+     */
+    public static boolean isAfter100(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_10_0_0) >= 0;
+    }
 
-	/**
-	 * Is the version of database after the 10.0.0
-	 *
-	 * @param database IDatabaseSpec
-	 * @return true:10.0.0 or higher
-	 */
-	public static boolean isAfter100(IDatabaseSpec database) {
-		return compareVersion(database.getVersion(), VER_10_0_0) >= 0;
-	}
+    /**
+     * Is the version of database after the 10.0.0
+     *
+     * @param database IDatabaseSpec
+     * @return true:10.0.0 or higher
+     */
+    public static boolean isAfter100(IDatabaseSpec database) {
+        return compareVersion(database.getVersion(), VER_10_0_0) >= 0;
+    }
 
-	/**
+    /**
      * Is the version of database after the 10.2.1
      *
      * @param database IServerSpec
@@ -388,617 +388,607 @@ public final class CompatibleUtil {
         return compareVersion(serverInfo.getServerVersionKey(), VER_11_0_1) >= 0;
     }
 
-	/**
-	 * Is the version of database after the 11.2.0
-	 *
-	 * @param database IServerSpec
-	 * @return true:11.2.0 or higher
-	 */
-	public static boolean isAfter112(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_11_2_0) >= 0;
-	}
-
-	/**
-	 * Retrieves whether the current client supports the cm server to connect.
-	 * (supports 8.2.x, 8.3.x, 8.4.0, 8.4.1, 8.4.3, 8.4.9, 9.0.0, 9.1.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @param clientVersion String
-	 * @return true:client supports the cm server to connect.
-	 */
-	public static boolean isSupportCMServer(IServerSpec serverInfo, String clientVersion) {
-		if (compareVersion(serverInfo.getServerVersionKey(), VER_8_2_0) < 0) {
-			return false;
-		}
-		//		if (compareVersion(serverInfo.getServerVersionKey(), VER_8_4_3) < 0) {
-		//			return true;
-		//		}
-		//client version bigger than or equal server version
-		if (compareVersion(clientVersion, serverInfo.getServerVersionKey(), 3) >= 0) {
-			return true;
-		}
-		/*if client version smaller than server version
-		 but server version is greater then 8.4.3 can support it too.*/
-		if (compareVersion(serverInfo.getServerVersionKey(), VER_8_4_3) >= 0) {
-			return true;
-		}
-		
-		return false;
-	}
-
-	/**
-	 * Retrieves whether the server supports Log papge size setting.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support;
-	 */
-	public static boolean isSupportLogPageSize(IServerSpec serverInfo) {
-		return isAfter822(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server supports verbose.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportVerbose(IServerSpec serverInfo) {
-		return isAfter822(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server supports NO_USE_Statistics
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportNoUseStatistics(IServerSpec serverInfo) {
-		return isAfter822(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server supports NewBrokerParamPropery
-	 * ConfConstants.CCI_PCONNECT;ConfConstants.SELECT_AUTO_COMMIT;
-	 * ConfConstants.ACCESS_MODE
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportNewBrokerParamPropery1(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-		return isAfter822(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the database supports serial cache.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportCache(IDatabaseSpec database) {
-		return isAfter822(database);
-	}
-
-	/**
-	 * Retrieves whether the database supports reuse OID in Create table
-	 * process.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportReuseOID(IDatabaseSpec database) {
-		return isAfter822(database);
-	}
-
-	/**
-	 * Retrieves whether the database supports reorder table in edit table
-	 * process.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportReorderColumn(IDatabaseSpec database) {
-		return isAfter840(database);
-	}
-
-	/**
-	 * Retrieves whether the database supports change command in edit table
-	 * process.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportChangeColumn(IDatabaseSpec database) {
-		return isAfter840(database);
-	}
-
-	/**
-	 * Retrieves whether the server support status monitor.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportBrokerOrDBStatusMonitor(IServerSpec serverInfo) {
-		return isAfter822(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server support plan/parameter dump.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportPlanAndParamDump(IServerSpec serverInfo) {
-		return isAfter822(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server support query/transaction time with ms.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isQueryOrTransTimeUseMs(IServerSpec serverInfo) {
-		return compareVersion(serverInfo.getServerVersionKey(), VER_8_2_1) >= 0;
-	}
-
-	/**
-	 * Retrieves whether the database support querying plan with user.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportQueryPlanWithUser(IDatabaseSpec database) {
-		return isAfter830(database);
-	}
-
-	/**
-	 * Retrieves whether the server support restore path in database restoring.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportRestorePath(IServerSpec serverInfo) {
-		return isAfter830(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the database support set null in adding/editing foreign key.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportSetNull(IDatabaseSpec database) {
-		return isAfter830(database);
-	}
-
-	/**
-	 * Retrieves whether the database support "replace view" in adding/editing view
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportReplaceView(IDatabaseSpec database) {
-		return isAfter830(database);
-	}
-
-	/**
-	 * Retrieves whether the database support "Create table like"
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportCreateTableLike(IDatabaseSpec database) {
-		return isAfter830(database);
-	}
-
-	/**
-	 * Retrieves whether support get cup and memory info task
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportGetCPUAndMemoryInfo (IDatabaseSpec database) {
-		return isAfter830(database);
-	}
-	/**
-	 * Retrieves whether the database support "truncate table"
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportTruncateTable(IDatabaseSpec database) {
-		return isAfter830(database);
-	}
-
-	/**
-	 * Retrieves whether the server support some new configurations of cm
-	 * server. the key and value separator is "=" or "\s", "=" is supported in
-	 * the below.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportNewFormatOfCMConf(IServerSpec serverInfo) {
-		return isAfter830(serverInfo);
-	}
-
-	/**
-	 * Return whether to need to check ha_mode status when create database
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isNeedCheckHAModeOnNewDb(IServerSpec serverInfo) {
-		return isAfter830(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server support getting parameter dump information
-	 * of databases.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportGetParamDump(IServerSpec serverInfo) {
-		return isAfter830(serverInfo);
-	}
-
-	/**
-	 * Retrieves the value type of index_scan_oid_buffer_pages of databases'
-	 * advanced parameters.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return string
-	 */
-	public static String getIndexScanOIDBufferPagesValueType(
-			IServerSpec serverInfo) {
-		if (isAfter830(serverInfo)) {
-			return "float(v>=0.05&&v<=16)";
-		}
-
-		return "int(v>=1&&v<=16)";
-	}
-
-	/**
-	 * Return whether support parameter "index_scan_oid_buffer_size"
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportIndexScanOIDBufferSize(IServerSpec serverInfo) {
-		return isAfter840(serverInfo);
-	}
-
-	/**
-	 * GET broker access mode value
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return string
-	 */
-	public static String getBrokerAccessModeValue(IServerSpec serverInfo) {
-		if (isSupportNewHABrokerParam(serverInfo)) {
-			return "string(RW|RO|SO|PHRO)";
-		}
-
-		return "string(RW|RO|SO)";
-	}
-
-	/**
-	 * Get ha_mode value
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return String
-	 */
-	public static String getHAModeValue(IServerSpec serverInfo) {
-		if (isSupportNewHABrokerParam(serverInfo)) {
-			return "string(on|off|yes|no|replica)";
-		}
-
-		return "string(on|off|yes|no)";
-	}
-
-	/**
-	 * Retrieves whether the current server's version support lob.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportLobVersion(IDatabaseSpec database) {
-		return isAfter831(database);
-	}
-
-	/**
-	 * Retrieves whether the current server's version support enum.
-	 *
-	 * @param database DatabaseInfo
-	 * @return true:support.
-	 */
-	public static boolean isSupportEnumVersion(IDatabaseSpec database) {
-		return isAfter900(database);
-	}
-
-	/**
-	 * Retrieves whether the server support system monitor.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportSystemMonitor(IServerSpec serverInfo) {
-		return isAfter831(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server support system monitor.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportDBSystemMonitor(IServerSpec serverInfo) {
-		return isAfter831(serverInfo) && !isWindows(serverInfo.getServerOsInfo());
-	}
-
-	/**
-	 * Retrieves whether the server support ConfConstants.HA_NODE_LIST and
-	 * ConfConstants.HA_PORT_ID
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportParamNodeListAndPortId(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		if (isWindows(serverInfo.getServerOsInfo())) {
-			return false;
-		}
-
-		if (isAfter840(serverInfo)) {
-			return false;
-		}
-
-		return isAfter822(serverInfo);
-	}
-
-	/**
-	 * Return whether to support new HA broker parameter including the below
-	 * <p>
-	 * Add replica value in ConfConstants.HA_MODE parameter from cubrid.conf
-	 * <p>
-	 * Add ConfConstants.PREFERRED_HOSTS and PHRO value in
-	 * ConfConstants.ACCESS_MODE parameter in cubrid_broker.conf
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportNewHABrokerParam(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		if (isWindows(serverInfo.getServerOsInfo())) {
-			return false;
-		}
-
-		return isAfter840(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server support HA.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isSupportHA(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		if (isWindows(serverInfo.getServerOsInfo())) {
-			return false;
-		}
-
-		return isAfter831(serverInfo);
-	}
-
-	/**
-	 * Return whether to support new HA configuration file(ha.conf)
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportNewHAConfFile(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		if (isWindows(serverInfo.getServerOsInfo())) {
-			return false;
-		}
-
-		return isAfter840(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server support "new broker diag" in monitoring dialog.
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:support.
-	 */
-	public static boolean isNewBrokerDiag(IServerSpec serverInfo) {
-		return isAfter831(serverInfo);
-	}
-
-	/**
-	 * Retrieves whether the server support broker port setting. Only windows system support.
-	 *
-	 * @param serverInfo the instance of IServerSpec
-	 * @return true:support;
-	 */
-	public static boolean isSupportBrokerPort(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-		FileUtil.OsInfoType osInfoType = serverInfo.getServerOsInfo();
-		return isWindows(osInfoType);
-	}
-
-	/**
-	 * Retrieves whether the os of server is windows
-	 *
-	 * @param osInfoType OsInfoType
-	 * @return true:is;
-	 */
-	public static boolean isWindows(FileUtil.OsInfoType osInfoType) {
-		return osInfoType == FileUtil.OsInfoType.NT;
-	}
-
-	/**
-	 * Retrieves whether the OS of server is AIX
-	 *
-	 * @param osInfoType OsInfoType
-	 * @return true:is;
-	 */
-	public static boolean isAIX(FileUtil.OsInfoType osInfoType) {
-		return osInfoType == FileUtil.OsInfoType.AIX;
-	}
-
-	/**
-	 * Return whether support JDBC cancel
-	 *
-	 * @param serverInfo the instance of IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportJDBCCancel(IServerSpec serverInfo) {
-		FileUtil.OsInfoType osType = serverInfo == null ? null : serverInfo.getServerOsInfo();
-		boolean isSupported = true;
-		if (osType == FileUtil.OsInfoType.NT) {
-			isSupported = false;
-		}
-
-		return isSupported;
-	}
-
-	/**
-	 * Return whether support prefix index length
-	 *
-	 * @param database DatabaseInfo
-	 * @return boolean
-	 */
-	public static boolean isSupportPrefixIndexLength(IDatabaseSpec database) {
-		return isAfter830(database);
-	}
-
-	/**
-	 * Return whether support cipher
-	 *
-	 * @param version String
-	 * @return boolean
-	 */
-	public static boolean isSupportCipher(String version) {
-		return compareVersion(parseServerVersion(version), VER_8_4_0) == 0;
-	}
-
-	/**
-	 * Parse the server version from "CUBRID 2008 R2.0(8.2.0.1150)" to "8.2.0"
-	 *
-	 * @param version String
-	 * @return version
-	 */
-	public static String parseServerVersion(String version) {
-		if (version == null) {
-			return "";
-		}
-
-		if (version.indexOf("(") != -1 && version.indexOf(")") != -1) {
-			String tmp = version.substring(1 + version.indexOf("("));
-			tmp = tmp.substring(0, tmp.indexOf(")"));
-			return tmp.substring(0, tmp.lastIndexOf("."));
-		}
-
-		return version;
-	}
-
-	/**
-	 * Return whether to support nlucene
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportNLucene(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		return isAfter840(serverInfo);
-	}
-
-	/**
-	 * Return whether support compact database online
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportOnlineCompactDb(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		return isAfter840(serverInfo);
-	}
-
-	/**
-	 * Return whether to support size properties including data_buffer_size,
-	 * log_buffer_size, sort_buffer_size
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportSizesPropInServer(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		return isAfter840(serverInfo);
-	}
-
-	/**
-	 * Return whether to support access_ip_control and access_ip_control_file
-	 * parameter
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportAccessIpControl(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		return isAfter840(serverInfo);
-	}
-
-	/**
-	 * Return whether to support enable_access_control and access_control_file
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return boolean
-	 */
-	public static boolean isSupportEnableAccessControl(IServerSpec serverInfo) {
-		if (serverInfo == null) {
-			return false;
-		}
-
-		if (isAfter1101(serverInfo)) {
-		    return false;
-		}
-
-		return isAfter840(serverInfo);
-	}
-
-	/**
+    /**
+     * Is the version of database after the 11.2.0
+     *
+     * @param database IServerSpec
+     * @return true:11.2.0 or higher
+     */
+    public static boolean isAfter112(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_11_2_0) >= 0;
+    }
+
+    /**
+     * Retrieves whether the current client supports the cm server to connect. (supports 8.2.x,
+     * 8.3.x, 8.4.0, 8.4.1, 8.4.3, 8.4.9, 9.0.0, 9.1.0
+     *
+     * @param serverInfo IServerSpec
+     * @param clientVersion String
+     * @return true:client supports the cm server to connect.
+     */
+    public static boolean isSupportCMServer(IServerSpec serverInfo, String clientVersion) {
+        if (compareVersion(serverInfo.getServerVersionKey(), VER_8_2_0) < 0) {
+            return false;
+        }
+        //		if (compareVersion(serverInfo.getServerVersionKey(), VER_8_4_3) < 0) {
+        //			return true;
+        //		}
+        // client version bigger than or equal server version
+        if (compareVersion(clientVersion, serverInfo.getServerVersionKey(), 3) >= 0) {
+            return true;
+        }
+        /*if client version smaller than server version
+        but server version is greater then 8.4.3 can support it too.*/
+        if (compareVersion(serverInfo.getServerVersionKey(), VER_8_4_3) >= 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieves whether the server supports Log papge size setting.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support;
+     */
+    public static boolean isSupportLogPageSize(IServerSpec serverInfo) {
+        return isAfter822(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server supports verbose.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportVerbose(IServerSpec serverInfo) {
+        return isAfter822(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server supports NO_USE_Statistics
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportNoUseStatistics(IServerSpec serverInfo) {
+        return isAfter822(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server supports NewBrokerParamPropery
+     * ConfConstants.CCI_PCONNECT;ConfConstants.SELECT_AUTO_COMMIT; ConfConstants.ACCESS_MODE
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportNewBrokerParamPropery1(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+        return isAfter822(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the database supports serial cache.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportCache(IDatabaseSpec database) {
+        return isAfter822(database);
+    }
+
+    /**
+     * Retrieves whether the database supports reuse OID in Create table process.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportReuseOID(IDatabaseSpec database) {
+        return isAfter822(database);
+    }
+
+    /**
+     * Retrieves whether the database supports reorder table in edit table process.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportReorderColumn(IDatabaseSpec database) {
+        return isAfter840(database);
+    }
+
+    /**
+     * Retrieves whether the database supports change command in edit table process.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportChangeColumn(IDatabaseSpec database) {
+        return isAfter840(database);
+    }
+
+    /**
+     * Retrieves whether the server support status monitor.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportBrokerOrDBStatusMonitor(IServerSpec serverInfo) {
+        return isAfter822(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server support plan/parameter dump.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportPlanAndParamDump(IServerSpec serverInfo) {
+        return isAfter822(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server support query/transaction time with ms.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isQueryOrTransTimeUseMs(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_8_2_1) >= 0;
+    }
+
+    /**
+     * Retrieves whether the database support querying plan with user.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportQueryPlanWithUser(IDatabaseSpec database) {
+        return isAfter830(database);
+    }
+
+    /**
+     * Retrieves whether the server support restore path in database restoring.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportRestorePath(IServerSpec serverInfo) {
+        return isAfter830(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the database support set null in adding/editing foreign key.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportSetNull(IDatabaseSpec database) {
+        return isAfter830(database);
+    }
+
+    /**
+     * Retrieves whether the database support "replace view" in adding/editing view
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportReplaceView(IDatabaseSpec database) {
+        return isAfter830(database);
+    }
+
+    /**
+     * Retrieves whether the database support "Create table like"
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportCreateTableLike(IDatabaseSpec database) {
+        return isAfter830(database);
+    }
+
+    /**
+     * Retrieves whether support get cup and memory info task
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportGetCPUAndMemoryInfo(IDatabaseSpec database) {
+        return isAfter830(database);
+    }
+    /**
+     * Retrieves whether the database support "truncate table"
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportTruncateTable(IDatabaseSpec database) {
+        return isAfter830(database);
+    }
+
+    /**
+     * Retrieves whether the server support some new configurations of cm server. the key and value
+     * separator is "=" or "\s", "=" is supported in the below.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportNewFormatOfCMConf(IServerSpec serverInfo) {
+        return isAfter830(serverInfo);
+    }
+
+    /**
+     * Return whether to need to check ha_mode status when create database
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isNeedCheckHAModeOnNewDb(IServerSpec serverInfo) {
+        return isAfter830(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server support getting parameter dump information of databases.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportGetParamDump(IServerSpec serverInfo) {
+        return isAfter830(serverInfo);
+    }
+
+    /**
+     * Retrieves the value type of index_scan_oid_buffer_pages of databases' advanced parameters.
+     *
+     * @param serverInfo IServerSpec
+     * @return string
+     */
+    public static String getIndexScanOIDBufferPagesValueType(IServerSpec serverInfo) {
+        if (isAfter830(serverInfo)) {
+            return "float(v>=0.05&&v<=16)";
+        }
+
+        return "int(v>=1&&v<=16)";
+    }
+
+    /**
+     * Return whether support parameter "index_scan_oid_buffer_size"
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportIndexScanOIDBufferSize(IServerSpec serverInfo) {
+        return isAfter840(serverInfo);
+    }
+
+    /**
+     * GET broker access mode value
+     *
+     * @param serverInfo IServerSpec
+     * @return string
+     */
+    public static String getBrokerAccessModeValue(IServerSpec serverInfo) {
+        if (isSupportNewHABrokerParam(serverInfo)) {
+            return "string(RW|RO|SO|PHRO)";
+        }
+
+        return "string(RW|RO|SO)";
+    }
+
+    /**
+     * Get ha_mode value
+     *
+     * @param serverInfo IServerSpec
+     * @return String
+     */
+    public static String getHAModeValue(IServerSpec serverInfo) {
+        if (isSupportNewHABrokerParam(serverInfo)) {
+            return "string(on|off|yes|no|replica)";
+        }
+
+        return "string(on|off|yes|no)";
+    }
+
+    /**
+     * Retrieves whether the current server's version support lob.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportLobVersion(IDatabaseSpec database) {
+        return isAfter831(database);
+    }
+
+    /**
+     * Retrieves whether the current server's version support enum.
+     *
+     * @param database DatabaseInfo
+     * @return true:support.
+     */
+    public static boolean isSupportEnumVersion(IDatabaseSpec database) {
+        return isAfter900(database);
+    }
+
+    /**
+     * Retrieves whether the server support system monitor.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportSystemMonitor(IServerSpec serverInfo) {
+        return isAfter831(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server support system monitor.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportDBSystemMonitor(IServerSpec serverInfo) {
+        return isAfter831(serverInfo) && !isWindows(serverInfo.getServerOsInfo());
+    }
+
+    /**
+     * Retrieves whether the server support ConfConstants.HA_NODE_LIST and ConfConstants.HA_PORT_ID
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportParamNodeListAndPortId(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        if (isWindows(serverInfo.getServerOsInfo())) {
+            return false;
+        }
+
+        if (isAfter840(serverInfo)) {
+            return false;
+        }
+
+        return isAfter822(serverInfo);
+    }
+
+    /**
+     * Return whether to support new HA broker parameter including the below
+     *
+     * <p>Add replica value in ConfConstants.HA_MODE parameter from cubrid.conf
+     *
+     * <p>Add ConfConstants.PREFERRED_HOSTS and PHRO value in ConfConstants.ACCESS_MODE parameter in
+     * cubrid_broker.conf
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportNewHABrokerParam(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        if (isWindows(serverInfo.getServerOsInfo())) {
+            return false;
+        }
+
+        return isAfter840(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server support HA.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isSupportHA(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        if (isWindows(serverInfo.getServerOsInfo())) {
+            return false;
+        }
+
+        return isAfter831(serverInfo);
+    }
+
+    /**
+     * Return whether to support new HA configuration file(ha.conf)
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportNewHAConfFile(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        if (isWindows(serverInfo.getServerOsInfo())) {
+            return false;
+        }
+
+        return isAfter840(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server support "new broker diag" in monitoring dialog.
+     *
+     * @param serverInfo IServerSpec
+     * @return true:support.
+     */
+    public static boolean isNewBrokerDiag(IServerSpec serverInfo) {
+        return isAfter831(serverInfo);
+    }
+
+    /**
+     * Retrieves whether the server support broker port setting. Only windows system support.
+     *
+     * @param serverInfo the instance of IServerSpec
+     * @return true:support;
+     */
+    public static boolean isSupportBrokerPort(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+        FileUtil.OsInfoType osInfoType = serverInfo.getServerOsInfo();
+        return isWindows(osInfoType);
+    }
+
+    /**
+     * Retrieves whether the os of server is windows
+     *
+     * @param osInfoType OsInfoType
+     * @return true:is;
+     */
+    public static boolean isWindows(FileUtil.OsInfoType osInfoType) {
+        return osInfoType == FileUtil.OsInfoType.NT;
+    }
+
+    /**
+     * Retrieves whether the OS of server is AIX
+     *
+     * @param osInfoType OsInfoType
+     * @return true:is;
+     */
+    public static boolean isAIX(FileUtil.OsInfoType osInfoType) {
+        return osInfoType == FileUtil.OsInfoType.AIX;
+    }
+
+    /**
+     * Return whether support JDBC cancel
+     *
+     * @param serverInfo the instance of IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportJDBCCancel(IServerSpec serverInfo) {
+        FileUtil.OsInfoType osType = serverInfo == null ? null : serverInfo.getServerOsInfo();
+        boolean isSupported = true;
+        if (osType == FileUtil.OsInfoType.NT) {
+            isSupported = false;
+        }
+
+        return isSupported;
+    }
+
+    /**
+     * Return whether support prefix index length
+     *
+     * @param database DatabaseInfo
+     * @return boolean
+     */
+    public static boolean isSupportPrefixIndexLength(IDatabaseSpec database) {
+        return isAfter830(database);
+    }
+
+    /**
+     * Return whether support cipher
+     *
+     * @param version String
+     * @return boolean
+     */
+    public static boolean isSupportCipher(String version) {
+        return compareVersion(parseServerVersion(version), VER_8_4_0) == 0;
+    }
+
+    /**
+     * Parse the server version from "CUBRID 2008 R2.0(8.2.0.1150)" to "8.2.0"
+     *
+     * @param version String
+     * @return version
+     */
+    public static String parseServerVersion(String version) {
+        if (version == null) {
+            return "";
+        }
+
+        if (version.indexOf("(") != -1 && version.indexOf(")") != -1) {
+            String tmp = version.substring(1 + version.indexOf("("));
+            tmp = tmp.substring(0, tmp.indexOf(")"));
+            return tmp.substring(0, tmp.lastIndexOf("."));
+        }
+
+        return version;
+    }
+
+    /**
+     * Return whether to support nlucene
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportNLucene(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        return isAfter840(serverInfo);
+    }
+
+    /**
+     * Return whether support compact database online
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportOnlineCompactDb(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        return isAfter840(serverInfo);
+    }
+
+    /**
+     * Return whether to support size properties including data_buffer_size, log_buffer_size,
+     * sort_buffer_size
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportSizesPropInServer(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        return isAfter840(serverInfo);
+    }
+
+    /**
+     * Return whether to support access_ip_control and access_ip_control_file parameter
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportAccessIpControl(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        return isAfter840(serverInfo);
+    }
+
+    /**
+     * Return whether to support enable_access_control and access_control_file
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportEnableAccessControl(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        if (isAfter1101(serverInfo)) {
+            return false;
+        }
+
+        return isAfter840(serverInfo);
+    }
+
+    /**
      * Return whether to support cci_default_autocommit
      *
      * @param serverInfo IServerSpec
@@ -1012,7 +1002,7 @@ public final class CompatibleUtil {
         return isAfter841(serverInfo);
     }
 
-	/**
+    /**
      * Return whether to support enable_access_control and access_control_file
      *
      * @param serverInfo IServerSpec
@@ -1026,316 +1016,309 @@ public final class CompatibleUtil {
         return isAfter1021(serverInfo);
     }
 
-	/**
-	 * Get supported page size
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return String[]
-	 */
-	public static String[] getSupportedPageSize(IServerSpec serverInfo) {
-		if (isAfter840(serverInfo)) {
-			return new String[]{"4096", "8192", "16384" };
-		} else {
-			return new String[]{"1024", "2048", "4096", "8192", "16384" };
-		}
-	}
+    /**
+     * Get supported page size
+     *
+     * @param serverInfo IServerSpec
+     * @return String[]
+     */
+    public static String[] getSupportedPageSize(IServerSpec serverInfo) {
+        if (isAfter840(serverInfo)) {
+            return new String[] {"4096", "8192", "16384"};
+        } else {
+            return new String[] {"1024", "2048", "4096", "8192", "16384"};
+        }
+    }
 
-	/**
-	 * Get default page size
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return String
-	 */
-	public static String getDefaultPageSize(IServerSpec serverInfo) {
-		if (isAfter840(serverInfo)) {
-			return "16384";
-		} else {
-			return "4096";
-		}
-	}
+    /**
+     * Get default page size
+     *
+     * @param serverInfo IServerSpec
+     * @return String
+     */
+    public static String getDefaultPageSize(IServerSpec serverInfo) {
+        if (isAfter840(serverInfo)) {
+            return "16384";
+        } else {
+            return "4096";
+        }
+    }
 
-	/**
-	 * Get the "db_volume_size" which is config in cubrid.conf
-	 *
-	 * @param serverInfo
-	 * @return the "db_volume_size" in the "cubrid.conf" of server.If
-	 *         databaseName is null, return the common setting value
-	 */
-	public static String getConfigGenericVolumeSize(IServerSpec serverInfo, String databaseName) {
-		if (serverInfo == null) {
-			return null;
-		}
+    /**
+     * Get the "db_volume_size" which is config in cubrid.conf
+     *
+     * @param serverInfo
+     * @return the "db_volume_size" in the "cubrid.conf" of server.If databaseName is null, return
+     *     the common setting value
+     */
+    public static String getConfigGenericVolumeSize(IServerSpec serverInfo, String databaseName) {
+        if (serverInfo == null) {
+            return null;
+        }
 
-		return serverInfo.getCubridConfPara("db_volume_size", databaseName);
-	}
+        return serverInfo.getCubridConfPara("db_volume_size", databaseName);
+    }
 
-	/**
-	 * Get the "log_volume_size" which is config in cubrid.conf
-	 *
-	 * @param serverInfo
-	 * @return the "log_volume_size" in the "cubrid.conf" of server. If
-	 *         databaseName is null, return the common setting value
-	 */
-	public static String getConfigLogVolumeSize(IServerSpec serverInfo, String databaseName) {
-		if (serverInfo == null) {
-			return null;
-		}
+    /**
+     * Get the "log_volume_size" which is config in cubrid.conf
+     *
+     * @param serverInfo
+     * @return the "log_volume_size" in the "cubrid.conf" of server. If databaseName is null, return
+     *     the common setting value
+     */
+    public static String getConfigLogVolumeSize(IServerSpec serverInfo, String databaseName) {
+        if (serverInfo == null) {
+            return null;
+        }
 
-		return serverInfo.getCubridConfPara("log_volume_size", databaseName);
-	}
+        return serverInfo.getCubridConfPara("log_volume_size", databaseName);
+    }
 
-	/**
-	 * Whether support query LIMIT clause
-	 *
-	 * @param databaseInfo
-	 * @return
-	 */
-	public static boolean isSupportLimit(IDatabaseSpec databaseInfo) {
-		if (databaseInfo == null) {
-			return false;
-		}
+    /**
+     * Whether support query LIMIT clause
+     *
+     * @param databaseInfo
+     * @return
+     */
+    public static boolean isSupportLimit(IDatabaseSpec databaseInfo) {
+        if (databaseInfo == null) {
+            return false;
+        }
 
-		return isAfter830(databaseInfo);
-	}
+        return isAfter830(databaseInfo);
+    }
 
-	/**
-	 * Whether support create db by charset
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:9.2.0 or higher
-	 */
-	public static boolean isSupportCreateDBByCharset(IServerSpec serverInfo) {
-		return isAfter920(serverInfo);
-	}
+    /**
+     * Whether support create db by charset
+     *
+     * @param serverInfo IServerSpec
+     * @return true:9.2.0 or higher
+     */
+    public static boolean isSupportCreateDBByCharset(IServerSpec serverInfo) {
+        return isAfter920(serverInfo);
+    }
 
-	/**
-	 * Whether support create db by charset
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:9.2.0 or higher
-	 */
-	public static boolean isSupportCreateDBByCharset(IDatabaseSpec databaseInfo) {
-		try {
-			return isAfter920(databaseInfo);
-		}
-		catch (Exception e) {
-			return false;
-		}
-	}
+    /**
+     * Whether support create db by charset
+     *
+     * @param serverInfo IServerSpec
+     * @return true:9.2.0 or higher
+     */
+    public static boolean isSupportCreateDBByCharset(IDatabaseSpec databaseInfo) {
+        try {
+            return isAfter920(databaseInfo);
+        } catch (Exception e) {
+            return false;
+        }
+    }
 
-	/**
-	 * Whether can get sub-partition table when get table list
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:9.0.0 or higher
-	 */
-	public static boolean isNotSupportGetSubPartitionTable(IServerSpec serverInfo) {
-		return isAfter910(serverInfo);
-	}
+    /**
+     * Whether can get sub-partition table when get table list
+     *
+     * @param serverInfo IServerSpec
+     * @return true:9.0.0 or higher
+     */
+    public static boolean isNotSupportGetSubPartitionTable(IServerSpec serverInfo) {
+        return isAfter910(serverInfo);
+    }
 
-	/**
-	 * Whether can be supported Shard
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:8.4.3 or higher
-	 */
-	public static boolean isSupportShard(IServerSpec serverInfo) {
-		return isAfter843(serverInfo);
-	}
+    /**
+     * Whether can be supported Shard
+     *
+     * @param serverInfo IServerSpec
+     * @return true:8.4.3 or higher
+     */
+    public static boolean isSupportShard(IServerSpec serverInfo) {
+        return isAfter843(serverInfo);
+    }
 
-	/**
-	 * Whether support auto backup/query plan by period or multi times
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:9.2.0(except AIX) or higher
-	 */
-	public static boolean isSupportPeriodicAutoJob(IServerSpec serverInfo){
-		// After CMS support auto update, need get CMS version to judge true or false
-		return isAfter920(serverInfo) && !isAIX(serverInfo.getServerOsInfo());
-	}
+    /**
+     * Whether support auto backup/query plan by period or multi times
+     *
+     * @param serverInfo IServerSpec
+     * @return true:9.2.0(except AIX) or higher
+     */
+    public static boolean isSupportPeriodicAutoJob(IServerSpec serverInfo) {
+        // After CMS support auto update, need get CMS version to judge true or false
+        return isAfter920(serverInfo) && !isAIX(serverInfo.getServerOsInfo());
+    }
 
-	/**
-	 * Whether support auto backup/query plan by period or multi times
-	 *
-	 * @param databaseInfo IDatabaseSpec
-	 * @return true:9.2.0(except AIX) or higher
-	 */
-	public static boolean isSupportPeriodicAutoJob(IDatabaseSpec databaseInfo) {
-		if (databaseInfo == null) {
-			return false;
-		}
-		return isAfter920(databaseInfo)
-				&& !isAIX(databaseInfo.getServerOsInfo());
-	}
+    /**
+     * Whether support auto backup/query plan by period or multi times
+     *
+     * @param databaseInfo IDatabaseSpec
+     * @return true:9.2.0(except AIX) or higher
+     */
+    public static boolean isSupportPeriodicAutoJob(IDatabaseSpec databaseInfo) {
+        if (databaseInfo == null) {
+            return false;
+        }
+        return isAfter920(databaseInfo) && !isAIX(databaseInfo.getServerOsInfo());
+    }
 
-	/**
-	 * Whether support monitor statistic feature
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true:9.2.0(except AIX) or higher
-	 */
-	public static boolean isSupportMonitorStatistic(IServerSpec serverInfo){
-		// After CMS support auto update, need get CMS version to judge true or false
-		return isAfter920(serverInfo) && !isAIX(serverInfo.getServerOsInfo());
-	}
+    /**
+     * Whether support monitor statistic feature
+     *
+     * @param serverInfo IServerSpec
+     * @return true:9.2.0(except AIX) or higher
+     */
+    public static boolean isSupportMonitorStatistic(IServerSpec serverInfo) {
+        // After CMS support auto update, need get CMS version to judge true or false
+        return isAfter920(serverInfo) && !isAIX(serverInfo.getServerOsInfo());
+    }
 
-	/**
-	 * Whether support specify backup volume name
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true: for CUBRID R2008, before 8.4.4, later version before 9.2.0
-	 */
-	public static boolean isSupportBackupVolumeName(IServerSpec serverInfo) {
-		if (isAfter844(serverInfo) && !isAfter900(serverInfo)) {
-			return false;
-		} else if (isAfter920(serverInfo)) {
-			return false;
-		}
-		return true;
-	}
+    /**
+     * Whether support specify backup volume name
+     *
+     * @param serverInfo IServerSpec
+     * @return true: for CUBRID R2008, before 8.4.4, later version before 9.2.0
+     */
+    public static boolean isSupportBackupVolumeName(IServerSpec serverInfo) {
+        if (isAfter844(serverInfo) && !isAfter900(serverInfo)) {
+            return false;
+        } else if (isAfter920(serverInfo)) {
+            return false;
+        }
+        return true;
+    }
 
-	/**
-	 * Whether support specify backup volume name
-	 *
-	 * @param databaseInfo IDatabaseSpec
-	 * @return true: for CUBRID R2008, before 8.4.4, later version before 9.2.0
-	 */
-	public static boolean isSupportBackupVolumeName(IDatabaseSpec databaseInfo) {
-		if (databaseInfo == null) {
-			return true;
-		}
-		if(isAfter844(databaseInfo) && !isAfter900(databaseInfo)){
-			return false;
-		}else if(isAfter920(databaseInfo)){
-			return false;
-		}
-		return true;
-	}
+    /**
+     * Whether support specify backup volume name
+     *
+     * @param databaseInfo IDatabaseSpec
+     * @return true: for CUBRID R2008, before 8.4.4, later version before 9.2.0
+     */
+    public static boolean isSupportBackupVolumeName(IDatabaseSpec databaseInfo) {
+        if (databaseInfo == null) {
+            return true;
+        }
+        if (isAfter844(databaseInfo) && !isAfter900(databaseInfo)) {
+            return false;
+        } else if (isAfter920(databaseInfo)) {
+            return false;
+        }
+        return true;
+    }
 
-	/**
-	 * Whether support new "killtransaction" API
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true: after 9.2.0
-	 */
-	public static boolean isSupportNewKillTranTask(IServerSpec serverInfo) {
-		return isAfter920(serverInfo);
-	}
+    /**
+     * Whether support new "killtransaction" API
+     *
+     * @param serverInfo IServerSpec
+     * @return true: after 9.2.0
+     */
+    public static boolean isSupportNewKillTranTask(IServerSpec serverInfo) {
+        return isAfter920(serverInfo);
+    }
 
-	/**
-	 * Whether support new "killtransaction" API
-	 *
-	 * @param databaseInfo IDatabaseSpec
-	 * @return true: after 9.2.0
-	 */
-	public static boolean isSupportNewKillTranTask(IDatabaseSpec databaseInfo) {
-		if (databaseInfo == null) {
-			return false;
-		}
+    /**
+     * Whether support new "killtransaction" API
+     *
+     * @param databaseInfo IDatabaseSpec
+     * @return true: after 9.2.0
+     */
+    public static boolean isSupportNewKillTranTask(IDatabaseSpec databaseInfo) {
+        if (databaseInfo == null) {
+            return false;
+        }
 
-		return isAfter920(databaseInfo);
-	}
+        return isAfter920(databaseInfo);
+    }
 
-	/**
-	 * Whether need check DBA authority by JDBC task <br>
-	 * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true: after 8.4.3
-	 */
-	public static boolean isNeedCheckDbaAuthorityByJDBC(IServerSpec serverInfo) {
-		//TODO: If new CUBRID version available or CMS patch for this, should update this method
-		return isAfter843(serverInfo);
-	}
+    /**
+     * Whether need check DBA authority by JDBC task <br>
+     * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true: after 8.4.3
+     */
+    public static boolean isNeedCheckDbaAuthorityByJDBC(IServerSpec serverInfo) {
+        // TODO: If new CUBRID version available or CMS patch for this, should update this method
+        return isAfter843(serverInfo);
+    }
 
-	/**
-	 * Whether need check DBA authority by JDBC task <br>
-	 * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
-	 *
-	 * @param databaseInfo IDatabaseSpec
-	 * @return true: after 8.4.3
-	 */
-	public static boolean isNeedCheckDbaAuthorityByJDBC(
-			IDatabaseSpec databaseInfo) {
-		//TODO: If new CUBRID version available or CMS patch for this, should update this method
-		if (databaseInfo == null) {
-			return false;
-		}
+    /**
+     * Whether need check DBA authority by JDBC task <br>
+     * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
+     *
+     * @param databaseInfo IDatabaseSpec
+     * @return true: after 8.4.3
+     */
+    public static boolean isNeedCheckDbaAuthorityByJDBC(IDatabaseSpec databaseInfo) {
+        // TODO: If new CUBRID version available or CMS patch for this, should update this method
+        if (databaseInfo == null) {
+            return false;
+        }
 
-		return isAfter843(databaseInfo);
-	}
+        return isAfter843(databaseInfo);
+    }
 
-	/**
-	 * Whether supports to keep number of backups on the backup automation<br>
-	 * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
-	 *
-	 * @param databaseSpec IDatabaseSpec
-	 * @return true: after 8.4.3
-	 */
-	public static boolean isBackupNumSupports(IDatabaseSpec databaseSpec) {
-		return isAfter843(databaseSpec);
-	}
+    /**
+     * Whether supports to keep number of backups on the backup automation<br>
+     * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
+     *
+     * @param databaseSpec IDatabaseSpec
+     * @return true: after 8.4.3
+     */
+    public static boolean isBackupNumSupports(IDatabaseSpec databaseSpec) {
+        return isAfter843(databaseSpec);
+    }
 
-	/**
-	 * Whether supports to keep number of backups on the backup automation<br>
-	 * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true: after 8.4.3
-	 */
-	public static boolean isBackupNumSupports(IServerSpec serverInfo) {
-		return isAfter843(serverInfo);
-	}
+    /**
+     * Whether supports to keep number of backups on the backup automation<br>
+     * <b>Note: <b>Only for 8.4.3/8.4.4/9.1.0/9.2.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true: after 8.4.3
+     */
+    public static boolean isBackupNumSupports(IServerSpec serverInfo) {
+        return isAfter843(serverInfo);
+    }
 
-	/**
-	 * Whether supports to comment on engine
-	 * <b>Note: <b>Only after 10.0.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return true: after 10.0.0
-	 */
-	public static boolean isCommentSupports(IServerSpec serverInfo) {
-		return isAfter100(serverInfo);
-	}
+    /**
+     * Whether supports to comment on engine <b>Note: <b>Only after 10.0.0
+     *
+     * @param serverInfo IServerSpec
+     * @return true: after 10.0.0
+     */
+    public static boolean isCommentSupports(IServerSpec serverInfo) {
+        return isAfter100(serverInfo);
+    }
 
-	/**
-	 * Whether supports to comment on engine
-	 * <b>Note: <b>Only after 10.0.0
-	 *
-	 * @param databaseSpec IDatabaseSpec
-	 * @return
-	 */
-	public static boolean isCommentSupports(IDatabaseSpec databaseSpec) {
-		return isAfter100(databaseSpec);
-	}
+    /**
+     * Whether supports to comment on engine <b>Note: <b>Only after 10.0.0
+     *
+     * @param databaseSpec IDatabaseSpec
+     * @return
+     */
+    public static boolean isCommentSupports(IDatabaseSpec databaseSpec) {
+        return isAfter100(databaseSpec);
+    }
 
-	/**
-	 * Whether supports functional index
-	 * <b>Note: <b>Only after 9.0.0
-	 *
-	 * @param databaseSpec IDatabaseSpec
-	 * @return
-	 */
-	public static boolean isSupportFuncIndex(IDatabaseSpec databaseSpec) {
-		return isAfter900(databaseSpec);
-	}
+    /**
+     * Whether supports functional index <b>Note: <b>Only after 9.0.0
+     *
+     * @param databaseSpec IDatabaseSpec
+     * @return
+     */
+    public static boolean isSupportFuncIndex(IDatabaseSpec databaseSpec) {
+        return isAfter900(databaseSpec);
+    }
 
-	/**
-	 * Whether supports functional index
-	 * <b>Note: <b>Only after 9.0.0
-	 *
-	 * @param serverInfo IServerSpec
-	 * @return
-	 */
-	public static boolean isSupportFuncIndex(IServerSpec serverInfo) {
-		return isAfter900(serverInfo);
-	}
+    /**
+     * Whether supports functional index <b>Note: <b>Only after 9.0.0
+     *
+     * @param serverInfo IServerSpec
+     * @return
+     */
+    public static boolean isSupportFuncIndex(IServerSpec serverInfo) {
+        return isAfter900(serverInfo);
+    }
 
-	public static boolean isSupportChangeOwnerWithAlterStatement(IDatabaseSpec databaseSpec) {
-		return isAfter900(databaseSpec);
-	}
+    public static boolean isSupportChangeOwnerWithAlterStatement(IDatabaseSpec databaseSpec) {
+        return isAfter900(databaseSpec);
+    }
 
-	public static boolean isSupportChangeOwnerWithAlterStatement(IServerSpec serverInfo) {
-		return isAfter900(serverInfo);
-	}
+    public static boolean isSupportChangeOwnerWithAlterStatement(IServerSpec serverInfo) {
+        return isAfter900(serverInfo);
+    }
 }

--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/CompatibleUtil.java
@@ -57,7 +57,9 @@ public final class CompatibleUtil {
 	private static final String VER_10_0_0 = "10.0.0";
 	private static final String VER_10_1_0 = "10.1.0";
 	private static final String VER_10_2_0 = "10.2.0";
+	private static final String VER_10_2_1 = "10.2.1";
 	private static final String VER_11_0_0 = "11.0.0";
+	private static final String VER_11_0_1 = "11.0.1";
 	private static final String VER_11_2_0 = "11.2.0"; //From 11.2 version, the engine and jdbc versioning  are different.
 
 	private CompatibleUtil() {
@@ -365,6 +367,26 @@ public final class CompatibleUtil {
 	public static boolean isAfter100(IDatabaseSpec database) {
 		return compareVersion(database.getVersion(), VER_10_0_0) >= 0;
 	}
+
+	/**
+     * Is the version of database after the 10.2.1
+     *
+     * @param database IServerSpec
+     * @return true:10.2.1 or higher
+     */
+    public static boolean isAfter1021(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_10_2_1) >= 0;
+    }
+
+    /**
+     * Is the version of database after the 11.0.1
+     *
+     * @param database IServerSpec
+     * @return true:11.0.1 or higher
+     */
+    public static boolean isAfter1101(IServerSpec serverInfo) {
+        return compareVersion(serverInfo.getServerVersionKey(), VER_11_0_1) >= 0;
+    }
 
 	/**
 	 * Is the version of database after the 11.2.0
@@ -969,8 +991,40 @@ public final class CompatibleUtil {
 			return false;
 		}
 
+		if (isAfter1101(serverInfo)) {
+		    return false;
+		}
+
 		return isAfter840(serverInfo);
 	}
+
+	/**
+     * Return whether to support cci_default_autocommit
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportCCIDefaultAutocommit(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        return isAfter841(serverInfo);
+    }
+
+	/**
+     * Return whether to support enable_access_control and access_control_file
+     *
+     * @param serverInfo IServerSpec
+     * @return boolean
+     */
+    public static boolean isSupportEnableOpenSSL(IServerSpec serverInfo) {
+        if (serverInfo == null) {
+            return false;
+        }
+
+        return isAfter1021(serverInfo);
+    }
 
 	/**
 	 * Get supported page size

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/Messages.properties
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/Messages.properties
@@ -72,10 +72,10 @@ btnConfirmRunModQueryAutoCommit=Ask for confirmation when running DDL/DML on Aut
 
 msgCubridHomePageUrl=http://www.cubrid.org
 msgCheckNewVersionUrl=http://www.cubrid.org
-msgCubridOnlineForumUrl=https://www.cubrid.org/community
+msgCubridOnlineForumUrl=https://www.reddit.com/r/CUBRID/
 msgCubridProjectSiteUrl=https://github.com/CUBRID
 msgCubridToolsSiteUrl=https://github.com/CUBRID/cubrid-manager
-msgCubridHelpSiteUrl=http://www.cubrid.org/documentation
+msgCubridHelpSiteUrl=http://www.cubrid.org
 msgCubridToolsNewFeatures=
 msgCubridJdbcInfoUrl=http://www.cubrid.org/manual/91/en/api/jdbc.html#jdbc-connection-conf
 titleAboutDialog=About {0}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/Messages_ko_KR.properties
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/Messages_ko_KR.properties
@@ -75,8 +75,8 @@ msgCheckNewVersionUrl=http://www.cubrid.com/zbxe/bbs_developer_release
 msgCubridOnlineForumUrl=http://www.cubrid.com/qna
 msgCubridProjectSiteUrl=https://github.com/CUBRID
 msgCubridToolsSiteUrl=https://github.com/CUBRID/cubrid-manager
-msgCubridHelpSiteUrl=http://www.cubrid.org/documentation
-msgCubridToolsNewFeatures=http://www.cubrid.org/wiki_tools/entry/release-note-summary_kr&l=en
+msgCubridHelpSiteUrl=http://www.cubrid.com
+msgCubridToolsNewFeatures=http://www.cubrid.com/release_note
 msgCubridJdbcInfoUrl=http://www.cubrid.org/manual/91/ko/api/jdbc.html#jdbc-connection-conf
 titleAboutDialog={0} \uc815\ubcf4
 aboutMessage=\n{0} {1} {2}\n\nCopyright (C) {3} Search Solution Corporation.\nAll rights reserved by Search Solution.\n\nWebsite: {4}\nCUBRID Manager project: {5}\nCUBRID Database project: {6}

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/action/CubridProjectSiteAction.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/action/CubridProjectSiteAction.java
@@ -58,7 +58,7 @@ public class CubridProjectSiteAction extends Action {
 	}
 
 	public void run() {
-		String url = CommonUITool.urlEncodeForSpaces(Messages.msgCubridProjectSiteUrl);
+		String url = CommonUITool.urlEncodeForSpaces(Messages.msgCubridToolsSiteUrl);
 
 		try {
 			IWorkbenchBrowserSupport support = PlatformUI.getWorkbench().getBrowserSupport();

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/action/CubridProjectSiteAction.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/action/CubridProjectSiteAction.java
@@ -27,9 +27,11 @@
  */
 package com.cubrid.common.ui.common.action;
 
+import com.cubrid.common.core.util.LogUtil;
+import com.cubrid.common.ui.common.Messages;
+import com.cubrid.common.ui.spi.util.CommonUITool;
 import java.net.MalformedURLException;
 import java.net.URL;
-
 import org.eclipse.jface.action.Action;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -37,37 +39,33 @@ import org.eclipse.ui.browser.IWebBrowser;
 import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
 import org.slf4j.Logger;
 
-import com.cubrid.common.core.util.LogUtil;
-import com.cubrid.common.ui.common.Messages;
-import com.cubrid.common.ui.spi.util.CommonUITool;
-
 /**
  * Open external browser and show CUBRID project site forum
- * 
+ *
  * @author pangqiren
  * @version 1.0 - 2009-06-15 created by pangqiren
  * @version 1.1 - 2012-09-05 updated by Isaiah Choe
  */
 public class CubridProjectSiteAction extends Action {
-	public static final String ID = CubridProjectSiteAction.class.getName();
-	private static final Logger LOGGER = LogUtil.getLogger(CubridProjectSiteAction.class);
+    public static final String ID = CubridProjectSiteAction.class.getName();
+    private static final Logger LOGGER = LogUtil.getLogger(CubridProjectSiteAction.class);
 
-	public CubridProjectSiteAction(String text) {
-		super(text);
-		this.setId(ID);
-	}
+    public CubridProjectSiteAction(String text) {
+        super(text);
+        this.setId(ID);
+    }
 
-	public void run() {
-		String url = CommonUITool.urlEncodeForSpaces(Messages.msgCubridToolsSiteUrl);
+    public void run() {
+        String url = CommonUITool.urlEncodeForSpaces(Messages.msgCubridToolsSiteUrl);
 
-		try {
-			IWorkbenchBrowserSupport support = PlatformUI.getWorkbench().getBrowserSupport();
-			IWebBrowser browser = support.getExternalBrowser();
-			browser.openURL(new URL(url));
-		} catch (PartInitException e) {
-			LOGGER.error("Can not initialize web browser on the application.", e);
-		} catch (MalformedURLException e) {
-			LOGGER.error("The url {} is invalid.", url, e);
-		}
-	}
+        try {
+            IWorkbenchBrowserSupport support = PlatformUI.getWorkbench().getBrowserSupport();
+            IWebBrowser browser = support.getExternalBrowser();
+            browser.openURL(new URL(url));
+        } catch (PartInitException e) {
+            LOGGER.error("Can not initialize web browser on the application.", e);
+        } catch (MalformedURLException e) {
+            LOGGER.error("The url {} is invalid.", url, e);
+        }
+    }
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/UrlConnUtil.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/UrlConnUtil.java
@@ -32,6 +32,9 @@ import static com.cubrid.common.ui.spi.util.CommonUITool.getVersionDateMill;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
+import com.cubrid.common.core.util.LogUtil;
+import com.cubrid.cubridmanager.core.common.xml.IXMLMemento;
+import com.cubrid.cubridmanager.core.common.xml.XMLMemento;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -41,13 +44,8 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Locale;
-
 import org.eclipse.core.runtime.Platform;
 import org.slf4j.Logger;
-
-import com.cubrid.common.core.util.LogUtil;
-import com.cubrid.cubridmanager.core.common.xml.IXMLMemento;
-import com.cubrid.cubridmanager.core.common.xml.XMLMemento;
 
 /**
  * This util class is responsible to connect some urls
@@ -56,177 +54,180 @@ import com.cubrid.cubridmanager.core.common.xml.XMLMemento;
  * @version 1.0 - 2009-6-23 created by pangqiren
  */
 public final class UrlConnUtil {
-	private static final Logger LOGGER = LogUtil.getLogger(UrlConnUtil.class);
-	private static final int TIME_OUT_MILL = 3000;
-	public static final String CHECK_NEW_INFO_URL_KO = "http://www.cubrid.com/news.htm";
-	public static final String CHECK_NEW_INFO_URL_EN = "http://www.cubrid.org/news.php";
-	public static final String CHECK_NEW_VERSION_URL_EN = "http://www.cubrid.org/check_version.cub";
-	public static final String CHECK_NEW_VERSION_URL_KO = "http://www.cubrid.com/check_version.cub";
-	public static final String CHECK_NOTICE_INFO_URL_KO = "http://ftp.cubrid.org/sites/inf/cqb/notice_ko.txt";
-	public static final String CHECK_NOTICE_INFO_URL_EN = "http://ftp.cubrid.org/sites/inf/cqb/notice.txt";
-	public static final String REPORT_BUG_URL_KO = "http://jira.cubrid.org";
-	public static final String REPORT_BUG_URL_EN = "http://jira.cubrid.org";
+    private static final Logger LOGGER = LogUtil.getLogger(UrlConnUtil.class);
+    private static final int TIME_OUT_MILL = 3000;
+    public static final String CHECK_NEW_INFO_URL_KO = "http://www.cubrid.com/news.htm";
+    public static final String CHECK_NEW_INFO_URL_EN = "http://www.cubrid.org/news.php";
+    public static final String CHECK_NEW_VERSION_URL_EN = "http://www.cubrid.org/check_version.cub";
+    public static final String CHECK_NEW_VERSION_URL_KO = "http://www.cubrid.com/check_version.cub";
+    public static final String CHECK_NOTICE_INFO_URL_KO =
+            "http://ftp.cubrid.org/sites/inf/cqb/notice_ko.txt";
+    public static final String CHECK_NOTICE_INFO_URL_EN =
+            "http://ftp.cubrid.org/sites/inf/cqb/notice.txt";
+    public static final String REPORT_BUG_URL_KO = "http://jira.cubrid.org";
+    public static final String REPORT_BUG_URL_EN = "http://jira.cubrid.org";
 
-	private UrlConnUtil() {
-		noOp();
-	}
+    private UrlConnUtil() {
+        noOp();
+    }
 
-	/**
-	 * Return whether the url can be connected
-	 *
-	 * @param url the url str
-	 * @return <code>true</code> if the url exist;<code>false</code>otherwise
-	 */
-	public static boolean isUrlExist(String url) {
-		HttpURLConnection conn = null;
-		try {
-			conn = (HttpURLConnection) new URL(url).openConnection();
-			conn.setRequestMethod("HEAD");
-			conn.setConnectTimeout(TIME_OUT_MILL);
-			conn.setReadTimeout(TIME_OUT_MILL);
-			if (conn.getResponseCode() == HTTP_OK) {
-				return true;
-			}
-		} catch (MalformedURLException e) {
-			LOGGER.error(e.getMessage(), e);
-		} catch (IOException e) {
-			LOGGER.error(e.getMessage(), e);
-		} finally {
-			if (conn != null) {
-				conn.disconnect();
-			}
-		}
+    /**
+     * Return whether the url can be connected
+     *
+     * @param url the url str
+     * @return <code>true</code> if the url exist;<code>false</code>otherwise
+     */
+    public static boolean isUrlExist(String url) {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(url).openConnection();
+            conn.setRequestMethod("HEAD");
+            conn.setConnectTimeout(TIME_OUT_MILL);
+            conn.setReadTimeout(TIME_OUT_MILL);
+            if (conn.getResponseCode() == HTTP_OK) {
+                return true;
+            }
+        } catch (MalformedURLException e) {
+            LOGGER.error(e.getMessage(), e);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * Get Url Content
-	 *
-	 * @param urlStr the url string
-	 * @param userAgent String
-	 * @return string the page content
-	 */
-	public static String getContent(String urlStr, String userAgent) {
-		HttpURLConnection conn = null;
-		BufferedReader in = null;
+    /**
+     * Get Url Content
+     *
+     * @param urlStr the url string
+     * @param userAgent String
+     * @return string the page content
+     */
+    public static String getContent(String urlStr, String userAgent) {
+        HttpURLConnection conn = null;
+        BufferedReader in = null;
 
-		try {
-			URL url = new URL(urlStr);
-			conn = (HttpURLConnection) url.openConnection();
-			conn.setRequestProperty("Http-User-Agent", userAgent);
-			conn.setConnectTimeout(TIME_OUT_MILL);
-			conn.setReadTimeout(TIME_OUT_MILL);
-			in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-			StringBuilder sb = new StringBuilder();
-			String inputLine;
-			while ((inputLine = in.readLine()) != null) {
-				sb.append(inputLine);
-				sb.append("\n");
-			}
+        try {
+            URL url = new URL(urlStr);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestProperty("Http-User-Agent", userAgent);
+            conn.setConnectTimeout(TIME_OUT_MILL);
+            conn.setReadTimeout(TIME_OUT_MILL);
+            in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            StringBuilder sb = new StringBuilder();
+            String inputLine;
+            while ((inputLine = in.readLine()) != null) {
+                sb.append(inputLine);
+                sb.append("\n");
+            }
 
-			return sb.toString();
-		} catch (MalformedURLException e) {
-			LOGGER.error(e.getMessage(), e);
-		} catch (IOException e) {
-			LOGGER.error(e.getMessage(), e);
-		} finally {
-			if (in != null) {
-				try {
-					in.close();
-				} catch (IOException e) {
-					LOGGER.error(e.getMessage(), e);
-				}
-			}
-			if (conn != null) {
-				conn.disconnect();
-			}
-		}
+            return sb.toString();
+        } catch (MalformedURLException e) {
+            LOGGER.error(e.getMessage(), e);
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e) {
+                    LOGGER.error(e.getMessage(), e);
+                }
+            }
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
 
-		return "";
-	}
+        return "";
+    }
 
-	/**
-	 *
-	 * Return whether CUBRID new version exist
-	 *
-	 * @param localVersion String
-	 * @param userAgent String
-	 * @return <code>true</code> if new cubrid version exist;<code>false</code>
-	 *         otherwise
-	 */
-	public static boolean isExistNewCubridVersion(String localVersion, String userAgent) {
-		String url = Platform.getNL().equals("ko_KR") ? CHECK_NEW_VERSION_URL_KO
-				: CHECK_NEW_VERSION_URL_EN;
-		if (!isUrlExist(url)) {
-			return false;
-		}
+    /**
+     * Return whether CUBRID new version exist
+     *
+     * @param localVersion String
+     * @param userAgent String
+     * @return <code>true</code> if new cubrid version exist;<code>false</code> otherwise
+     */
+    public static boolean isExistNewCubridVersion(String localVersion, String userAgent) {
+        String url =
+                Platform.getNL().equals("ko_KR")
+                        ? CHECK_NEW_VERSION_URL_KO
+                        : CHECK_NEW_VERSION_URL_EN;
+        if (!isUrlExist(url)) {
+            return false;
+        }
 
-		String content = getContent(url, userAgent);
-		if (isBlank(content)) {
-			return false;
-		}
-		content = content.toUpperCase(Locale.getDefault());
-		if (content.indexOf("<HTML") >= 0) {
-			content = content.substring(content.indexOf("<HTML"));
-		}
+        String content = getContent(url, userAgent);
+        if (isBlank(content)) {
+            return false;
+        }
+        content = content.toUpperCase(Locale.getDefault());
+        if (content.indexOf("<HTML") >= 0) {
+            content = content.substring(content.indexOf("<HTML"));
+        }
 
-		try {
-			ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes("UTF-8"));
-			IXMLMemento memento = XMLMemento.loadMemento(in);
-			if (memento == null) {
-				return false;
-			}
-			IXMLMemento[] children = memento.getChildren("BODY");
-			if (children != null && children.length == 1) {
-				content = children[0].getTextData();
-			}
-		} catch (UnsupportedEncodingException e) {
-			LOGGER.error(e.getMessage(), e);
-			return false;
-		}
+        try {
+            ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes("UTF-8"));
+            IXMLMemento memento = XMLMemento.loadMemento(in);
+            if (memento == null) {
+                return false;
+            }
+            IXMLMemento[] children = memento.getChildren("BODY");
+            if (children != null && children.length == 1) {
+                content = children[0].getTextData();
+            }
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.error(e.getMessage(), e);
+            return false;
+        }
 
-		return compareVersion(content, localVersion);
-	}
+        return compareVersion(content, localVersion);
+    }
 
-	/**
-	 * Compare the version
-	 *
-	 * @param serverVersion the server version
-	 * @param localVersion the local version
-	 * @return <code>true</code> if new cubrid version exist;<code>false</code>
-	 *         otherwise
-	 */
-	private static boolean compareVersion(String serverVersion, String localVersion) {
-		if (serverVersion == null || serverVersion.trim().length() == 0
-				|| !serverVersion.trim().matches("^(\\d+\\.){3}\\d+$")) {
-			return false;
-		}
-		if (localVersion == null || localVersion.trim().length() == 0
-				|| !localVersion.trim().matches("^(\\d+\\.){3}\\d+$")) {
-			return false;
-		}
-		String[] latestBuildIdArr = serverVersion.trim().split("\\.");
-		String[] localBuildIdArr = localVersion.split("\\.");
-		if (latestBuildIdArr == null || localBuildIdArr == null) {
-			return false;
-		}
+    /**
+     * Compare the version
+     *
+     * @param serverVersion the server version
+     * @param localVersion the local version
+     * @return <code>true</code> if new cubrid version exist;<code>false</code> otherwise
+     */
+    private static boolean compareVersion(String serverVersion, String localVersion) {
+        if (serverVersion == null
+                || serverVersion.trim().length() == 0
+                || !serverVersion.trim().matches("^(\\d+\\.){3}\\d+$")) {
+            return false;
+        }
+        if (localVersion == null
+                || localVersion.trim().length() == 0
+                || !localVersion.trim().matches("^(\\d+\\.){3}\\d+$")) {
+            return false;
+        }
+        String[] latestBuildIdArr = serverVersion.trim().split("\\.");
+        String[] localBuildIdArr = localVersion.split("\\.");
+        if (latestBuildIdArr == null || localBuildIdArr == null) {
+            return false;
+        }
 
-		for (int i = 0; i < localBuildIdArr.length && i < latestBuildIdArr.length; i++) {
-			try {
-				long localBuildId = getVersionDateMill(localBuildIdArr[i]);
-				long latestBuildId = getVersionDateMill(latestBuildIdArr[i]);
-				if (latestBuildId > localBuildId) {
-					return true;
-				} else if (latestBuildId < localBuildId) {
-					return false;
-				}
-			} catch (Exception e) {
-				LOGGER.error(e.getMessage(), e);
-				return false;
-			}
-		}
+        for (int i = 0; i < localBuildIdArr.length && i < latestBuildIdArr.length; i++) {
+            try {
+                long localBuildId = getVersionDateMill(localBuildIdArr[i]);
+                long latestBuildId = getVersionDateMill(latestBuildIdArr[i]);
+                if (latestBuildId > localBuildId) {
+                    return true;
+                } else if (latestBuildId < localBuildId) {
+                    return false;
+                }
+            } catch (Exception e) {
+                LOGGER.error(e.getMessage(), e);
+                return false;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/UrlConnUtil.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/util/UrlConnUtil.java
@@ -64,7 +64,7 @@ public final class UrlConnUtil {
 	public static final String CHECK_NEW_VERSION_URL_KO = "http://www.cubrid.com/check_version.cub";
 	public static final String CHECK_NOTICE_INFO_URL_KO = "http://ftp.cubrid.org/sites/inf/cqb/notice_ko.txt";
 	public static final String CHECK_NOTICE_INFO_URL_EN = "http://ftp.cubrid.org/sites/inf/cqb/notice.txt";
-	public static final String REPORT_BUG_URL_KO = "http://www.cubrid.com/zbxe/bbs_developer_qa";
+	public static final String REPORT_BUG_URL_KO = "http://jira.cubrid.org";
 	public static final String REPORT_BUG_URL_EN = "http://jira.cubrid.org";
 
 	private UrlConnUtil() {

--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/ConfConstants.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/ConfConstants.java
@@ -30,395 +30,373 @@ package com.cubrid.cubridmanager.core.common.model;
 import com.cubrid.common.core.util.CompatibleUtil;
 
 /**
- *
- * CUBRID Configuration parameter constants for cubrid.conf and cm.conf and
- * cubrid_broker.conf
+ * CUBRID Configuration parameter constants for cubrid.conf and cm.conf and cubrid_broker.conf
  *
  * @author pangqiren
  * @version 1.0 - 2009-6-4 created by pangqiren
  */
-public final class ConfConstants implements
-		CubridConfParaConstants,
-		CubridBrokerConfParaConstants,
-		CubridManagerConfParaConstants,
-		HAConfParaConstants {
+public final class ConfConstants
+        implements CubridConfParaConstants,
+                CubridBrokerConfParaConstants,
+                CubridManagerConfParaConstants,
+                HAConfParaConstants {
 
-	public static final String DEFAULT_DATA_VOLUME_SIZE = "512";
+    public static final String DEFAULT_DATA_VOLUME_SIZE = "512";
 
-	private static String[][] dbBaseParameters = {
-			{DATA_BUFFER_PAGES, "25000", PARAMETER_TYPE_SERVER },
-			{DATA_BUFFER_SIZE, "512M", PARAMETER_TYPE_SERVER },
-			{SORT_BUFFER_PAGES, "16", PARAMETER_TYPE_SERVER },
-			{SORT_BUFFER_SIZE, "2M", PARAMETER_TYPE_SERVER },
-			{LOG_BUFFER_PAGES, "50", PARAMETER_TYPE_SERVER },
-			{LOG_BUFFER_SIZE, "4M", PARAMETER_TYPE_SERVER },
-			{LOCK_ESCALATION, "100000", PARAMETER_TYPE_SERVER },
-			{LOCK_TIMEOUT_IN_SECS, "-1", PARAMETER_TYPE_SERVER },
-			{DEADLOCK_DETECTION_INTERVAL_IN_SECS, "1", PARAMETER_TYPE_SERVER },
-			{CHECKPOINT_INTERVAL_IN_MINS, "1000", PARAMETER_TYPE_SERVER },
-			{ISOLATION_LEVEL, "\"" + TRAN_REP_CLASS_UNCOMMIT_INSTANCE + "\"",
-					PARAMETER_TYPE_SERVER },
-			{CUBRID_PORT_ID, "1523", PARAMETER_TYPE_CLIENT },
-			{MAX_CLIENTS, "100", PARAMETER_TYPE_SERVER },
-			{AUTO_RESTART_SERVER, "no", PARAMETER_TYPE_SERVER },
-			{REPLICATION, "no", PARAMETER_TYPE_SERVER } };
+    private static String[][] dbBaseParameters = {
+        {DATA_BUFFER_PAGES, "25000", PARAMETER_TYPE_SERVER},
+        {DATA_BUFFER_SIZE, "512M", PARAMETER_TYPE_SERVER},
+        {SORT_BUFFER_PAGES, "16", PARAMETER_TYPE_SERVER},
+        {SORT_BUFFER_SIZE, "2M", PARAMETER_TYPE_SERVER},
+        {LOG_BUFFER_PAGES, "50", PARAMETER_TYPE_SERVER},
+        {LOG_BUFFER_SIZE, "4M", PARAMETER_TYPE_SERVER},
+        {LOCK_ESCALATION, "100000", PARAMETER_TYPE_SERVER},
+        {LOCK_TIMEOUT_IN_SECS, "-1", PARAMETER_TYPE_SERVER},
+        {DEADLOCK_DETECTION_INTERVAL_IN_SECS, "1", PARAMETER_TYPE_SERVER},
+        {CHECKPOINT_INTERVAL_IN_MINS, "1000", PARAMETER_TYPE_SERVER},
+        {ISOLATION_LEVEL, "\"" + TRAN_REP_CLASS_UNCOMMIT_INSTANCE + "\"", PARAMETER_TYPE_SERVER},
+        {CUBRID_PORT_ID, "1523", PARAMETER_TYPE_CLIENT},
+        {MAX_CLIENTS, "100", PARAMETER_TYPE_SERVER},
+        {AUTO_RESTART_SERVER, "no", PARAMETER_TYPE_SERVER},
+        {REPLICATION, "no", PARAMETER_TYPE_SERVER}
+    };
 
-	/**
-	 * Get the static field dbBaseParameters
-	 *
-	 * @param serverInfo the ServerInfo
-	 * @return String[][]
-	 */
-	public static String[][] getDbBaseParameters(ServerInfo serverInfo) {
-		boolean isSupportSizes = CompatibleUtil.isSupportSizesPropInServer(serverInfo);
-		String copy[][] = null;
-		if (isSupportSizes) {
-			copy = new String[dbBaseParameters.length][];
-			for (int i = 0; i < dbBaseParameters.length; i++) {
-				copy[i] = (String[]) dbBaseParameters[i].clone();
-			}
-		} else {
-			copy = new String[dbBaseParameters.length - 3][];
-			for (int i = 0, k = 0; i < dbBaseParameters.length; i++) {
-				if (DATA_BUFFER_SIZE.equals(dbBaseParameters[i][0])
-						|| SORT_BUFFER_SIZE.equals(dbBaseParameters[i][0])
-						|| LOG_BUFFER_SIZE.equals(dbBaseParameters[i][0])) {
-					continue;
-				}
-				if (MAX_CLIENTS.equals(dbBaseParameters[i][0])) {
-					copy[k] = new String[3];
-					copy[k][0] = MAX_CLIENTS;
-					copy[k][1] = "50";
-					copy[k][2] = dbBaseParameters[i][2];
-					k++;
-					continue;
-				}
-				copy[k] = (String[]) dbBaseParameters[i].clone();
-				k++;
-			}
-		}
-		return copy;
-	}
+    /**
+     * Get the static field dbBaseParameters
+     *
+     * @param serverInfo the ServerInfo
+     * @return String[][]
+     */
+    public static String[][] getDbBaseParameters(ServerInfo serverInfo) {
+        boolean isSupportSizes = CompatibleUtil.isSupportSizesPropInServer(serverInfo);
+        String copy[][] = null;
+        if (isSupportSizes) {
+            copy = new String[dbBaseParameters.length][];
+            for (int i = 0; i < dbBaseParameters.length; i++) {
+                copy[i] = (String[]) dbBaseParameters[i].clone();
+            }
+        } else {
+            copy = new String[dbBaseParameters.length - 3][];
+            for (int i = 0, k = 0; i < dbBaseParameters.length; i++) {
+                if (DATA_BUFFER_SIZE.equals(dbBaseParameters[i][0])
+                        || SORT_BUFFER_SIZE.equals(dbBaseParameters[i][0])
+                        || LOG_BUFFER_SIZE.equals(dbBaseParameters[i][0])) {
+                    continue;
+                }
+                if (MAX_CLIENTS.equals(dbBaseParameters[i][0])) {
+                    copy[k] = new String[3];
+                    copy[k][0] = MAX_CLIENTS;
+                    copy[k][1] = "50";
+                    copy[k][2] = dbBaseParameters[i][2];
+                    k++;
+                    continue;
+                }
+                copy[k] = (String[]) dbBaseParameters[i].clone();
+                k++;
+            }
+        }
+        return copy;
+    }
 
-	private static String[][] dbAdvancedParameters = {
-			{ACCESS_IP_CONTROL, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER },
-			{ACCESS_IP_CONTROL_FILE, "string", "", PARAMETER_TYPE_SERVER },
-			{ASYNC_COMMIT, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER },
-			{BACKUP_VOLUME_MAX_SIZE_BYTES, "int(v>=32*1024)", "-1",
-					PARAMETER_TYPE_SERVER },
-			{BLOCK_DDL_STATEMENT, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT },
-			{BLOCK_NOWHERE_STATEMENT, "bool(yes|no)", "no",
-					PARAMETER_TYPE_CLIENT },
-			{CALL_STACK_DUMP_ACTIVATION_LIST, "string", "", PARAMETER_TYPE_BOTH },
-			{CALL_STACK_DUMP_DEACTIVATION_LIST, "string", "",
-					PARAMETER_TYPE_BOTH },
-			{CALL_STACK_DUMP_ON_ERROR, "bool(yes|no)", "no",
-					PARAMETER_TYPE_BOTH },
-			{COMPACTDB_PAGE_RECLAIM_ONLY, "int", "0", PARAMETER_TYPE_UTILITY },
-			{COMPAT_NUMERIC_DIVISION_SCALE, "bool(yes|no)", "no",
-					PARAMETER_TYPE_BOTH },
-			{COMPAT_PRIMARY_KEY, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT },
-			{CSQL_HISTORY_NUM, "int(v>=1&&v<=200)", "50", PARAMETER_TYPE_CLIENT },
-			{DB_HOSTS, "string", "", PARAMETER_TYPE_CLIENT },
-			{DONT_REUSE_HEAP_FILE, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER },
-			{ERROR_LOG, "string", "cubrid.err", PARAMETER_TYPE_BOTH },
-			{FILE_LOCK, "bool(yes|no)", "yes", PARAMETER_TYPE_SERVER },
-			{GARBAGE_COLLECTION, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT },
-			{GROUP_COMMIT_INTERVAL_IN_MSECS, "int(v>=0)", "0",
-					PARAMETER_TYPE_SERVER },
-			{HA_MODE, "string(on|off|yes|no)", "off", PARAMETER_TYPE_SERVER },
-			{HA_NODE_LIST, "string", "", PARAMETER_TYPE_SERVER },
-			{HA_PORT_ID, "int(v>=1024&&v<=65535)", "", PARAMETER_TYPE_SERVER },
-			{HOSTVAR_LATE_BINDING, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT },
-			{INDEX_SCAN_IN_OID_ORDER, "bool(yes|no)", "no",
-					PARAMETER_TYPE_CLIENT },
-			//if version>=8.2.2 float(v>=0.05&&v<=16);otherwise,int(v>=1&&v<=16)
-			{INDEX_SCAN_OID_BUFFER_PAGES, "int(v>=1&&v<=16)", "4",
-					PARAMETER_TYPE_SERVER },
-			{INSERT_EXECUTION_MODE, "int(v>=1&&v<=7)", "1",
-					PARAMETER_TYPE_CLIENT },
-			{INTL_MBS_SUPPORT, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT },
-			{LOCK_TIMEOUT_MESSAGE_TYPE, "int(v>=0&&v<=2)", "0",
-					PARAMETER_TYPE_SERVER },
-			{MAX_PLAN_CACHE_ENTRIES, "int", "1000", PARAMETER_TYPE_BOTH },
-			{MAX_QUERY_CACHE_ENTRIES, "int", "-1", PARAMETER_TYPE_SERVER },
-			{MEDIA_FAILURE_SUPPORT, "bool(yes|no)", "yes",
-					PARAMETER_TYPE_SERVER },
-			{ORACLE_STYLE_EMPTY_STRING, "bool(yes|no)", "no",
-					PARAMETER_TYPE_CLIENT },
-			{ORACLE_STYLE_OUTERJOIN, "bool(yes|no)", "no",
-					PARAMETER_TYPE_CLIENT },
-			{PTHREAD_SCOPE_PROCESS, "bool(yes|no)", "yes",
-					PARAMETER_TYPE_SERVER },
-			{QUERY_CACHE_MODE, "int(v>=0&&v<=2)", "0", PARAMETER_TYPE_SERVER },
-			{QUERY_CACHE_SIZE_IN_PAGES, "int", "-1", PARAMETER_TYPE_SERVER },
-			{SINGLE_BYTE_COMPARE, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER },
-			{TEMP_FILE_MAX_SIZE_IN_PAGES, "int", "-1", PARAMETER_TYPE_SERVER },
-			{TEMP_FILE_MEMORY_SIZE_IN_PAGES, "int(v>=0&&v<=20)", "4",
-					PARAMETER_TYPE_SERVER },
-			{TEMP_VOLUME_PATH, "string", "", PARAMETER_TYPE_SERVER },
-			{THREAD_STACK_SIZE, "int(v>=64*1024)", "100*1024",
-					PARAMETER_TYPE_SERVER },
-			{UNFILL_FACTOR, "float(v>=0&&v<=0.3)", "0.1", PARAMETER_TYPE_SERVER },
-			{VOLUME_EXTENSION_PATH, "string", "", PARAMETER_TYPE_SERVER } };
+    private static String[][] dbAdvancedParameters = {
+        {ACCESS_IP_CONTROL, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER},
+        {ACCESS_IP_CONTROL_FILE, "string", "", PARAMETER_TYPE_SERVER},
+        {ASYNC_COMMIT, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER},
+        {BACKUP_VOLUME_MAX_SIZE_BYTES, "int(v>=32*1024)", "-1", PARAMETER_TYPE_SERVER},
+        {BLOCK_DDL_STATEMENT, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {BLOCK_NOWHERE_STATEMENT, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {CALL_STACK_DUMP_ACTIVATION_LIST, "string", "", PARAMETER_TYPE_BOTH},
+        {CALL_STACK_DUMP_DEACTIVATION_LIST, "string", "", PARAMETER_TYPE_BOTH},
+        {CALL_STACK_DUMP_ON_ERROR, "bool(yes|no)", "no", PARAMETER_TYPE_BOTH},
+        {COMPACTDB_PAGE_RECLAIM_ONLY, "int", "0", PARAMETER_TYPE_UTILITY},
+        {COMPAT_NUMERIC_DIVISION_SCALE, "bool(yes|no)", "no", PARAMETER_TYPE_BOTH},
+        {COMPAT_PRIMARY_KEY, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {CSQL_HISTORY_NUM, "int(v>=1&&v<=200)", "50", PARAMETER_TYPE_CLIENT},
+        {DB_HOSTS, "string", "", PARAMETER_TYPE_CLIENT},
+        {DONT_REUSE_HEAP_FILE, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER},
+        {ERROR_LOG, "string", "cubrid.err", PARAMETER_TYPE_BOTH},
+        {FILE_LOCK, "bool(yes|no)", "yes", PARAMETER_TYPE_SERVER},
+        {GARBAGE_COLLECTION, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {GROUP_COMMIT_INTERVAL_IN_MSECS, "int(v>=0)", "0", PARAMETER_TYPE_SERVER},
+        {HA_MODE, "string(on|off|yes|no)", "off", PARAMETER_TYPE_SERVER},
+        {HA_NODE_LIST, "string", "", PARAMETER_TYPE_SERVER},
+        {HA_PORT_ID, "int(v>=1024&&v<=65535)", "", PARAMETER_TYPE_SERVER},
+        {HOSTVAR_LATE_BINDING, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {INDEX_SCAN_IN_OID_ORDER, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        // if version>=8.2.2 float(v>=0.05&&v<=16);otherwise,int(v>=1&&v<=16)
+        {INDEX_SCAN_OID_BUFFER_PAGES, "int(v>=1&&v<=16)", "4", PARAMETER_TYPE_SERVER},
+        {INSERT_EXECUTION_MODE, "int(v>=1&&v<=7)", "1", PARAMETER_TYPE_CLIENT},
+        {INTL_MBS_SUPPORT, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {LOCK_TIMEOUT_MESSAGE_TYPE, "int(v>=0&&v<=2)", "0", PARAMETER_TYPE_SERVER},
+        {MAX_PLAN_CACHE_ENTRIES, "int", "1000", PARAMETER_TYPE_BOTH},
+        {MAX_QUERY_CACHE_ENTRIES, "int", "-1", PARAMETER_TYPE_SERVER},
+        {MEDIA_FAILURE_SUPPORT, "bool(yes|no)", "yes", PARAMETER_TYPE_SERVER},
+        {ORACLE_STYLE_EMPTY_STRING, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {ORACLE_STYLE_OUTERJOIN, "bool(yes|no)", "no", PARAMETER_TYPE_CLIENT},
+        {PTHREAD_SCOPE_PROCESS, "bool(yes|no)", "yes", PARAMETER_TYPE_SERVER},
+        {QUERY_CACHE_MODE, "int(v>=0&&v<=2)", "0", PARAMETER_TYPE_SERVER},
+        {QUERY_CACHE_SIZE_IN_PAGES, "int", "-1", PARAMETER_TYPE_SERVER},
+        {SINGLE_BYTE_COMPARE, "bool(yes|no)", "no", PARAMETER_TYPE_SERVER},
+        {TEMP_FILE_MAX_SIZE_IN_PAGES, "int", "-1", PARAMETER_TYPE_SERVER},
+        {TEMP_FILE_MEMORY_SIZE_IN_PAGES, "int(v>=0&&v<=20)", "4", PARAMETER_TYPE_SERVER},
+        {TEMP_VOLUME_PATH, "string", "", PARAMETER_TYPE_SERVER},
+        {THREAD_STACK_SIZE, "int(v>=64*1024)", "100*1024", PARAMETER_TYPE_SERVER},
+        {UNFILL_FACTOR, "float(v>=0&&v<=0.3)", "0.1", PARAMETER_TYPE_SERVER},
+        {VOLUME_EXTENSION_PATH, "string", "", PARAMETER_TYPE_SERVER}
+    };
 
-	/**
-	 *
-	 * Get the static field dbAdvancedParameters
-	 *
-	 * @param serverInfo The ServerInfo object
-	 * @param isCommon boolean
-	 * @return String[][]
-	 */
-	public static String[][] getDbAdvancedParameters(ServerInfo serverInfo,
-			boolean isCommon) {
-		int length = dbAdvancedParameters.length;
-		boolean isSupportNewDbPro = CompatibleUtil.isSupportParamNodeListAndPortId(serverInfo)
-				&& isCommon;
-		if (!isSupportNewDbPro) {
-			length = length - 2;
-		}
+    /**
+     * Get the static field dbAdvancedParameters
+     *
+     * @param serverInfo The ServerInfo object
+     * @param isCommon boolean
+     * @return String[][]
+     */
+    public static String[][] getDbAdvancedParameters(ServerInfo serverInfo, boolean isCommon) {
+        int length = dbAdvancedParameters.length;
+        boolean isSupportNewDbPro =
+                CompatibleUtil.isSupportParamNodeListAndPortId(serverInfo) && isCommon;
+        if (!isSupportNewDbPro) {
+            length = length - 2;
+        }
 
-		boolean isSupportAccessIpControl = CompatibleUtil.isSupportAccessIpControl(serverInfo);
-		if (!isSupportAccessIpControl) {
-			length = length - 2;
-		}
-		String copy[][] = new String[length][];
-		int j = 0;
-		for (int i = 0; i < dbAdvancedParameters.length; i++) {
-			if (!isSupportNewDbPro
-					&& (dbAdvancedParameters[i][0].equals(ConfConstants.HA_NODE_LIST) || dbAdvancedParameters[i][0].equals(ConfConstants.HA_PORT_ID))) {
-				continue;
-			}
-			if (!isSupportAccessIpControl
-					&& (dbAdvancedParameters[i][0].equals(ConfConstants.ACCESS_IP_CONTROL) || dbAdvancedParameters[i][0].equals(ConfConstants.ACCESS_IP_CONTROL_FILE))) {
-				continue;
-			}
-			copy[j] = (String[]) dbAdvancedParameters[i].clone();
-			if (serverInfo != null
-					&& dbAdvancedParameters[i][0].equals(INDEX_SCAN_OID_BUFFER_PAGES)) {
-				if (CompatibleUtil.isSupportIndexScanOIDBufferSize(serverInfo)) {
-					copy[j][0] = INDEX_SCAN_OID_BUFFER_SIZE;
-					copy[j][1] = "int(v>=64*1024)";
-					copy[j][2] = "64*1024";
-					copy[j][3] = PARAMETER_TYPE_SERVER;
-				} else {
-					copy[j][1] = CompatibleUtil.getIndexScanOIDBufferPagesValueType(serverInfo);
-				}
+        boolean isSupportAccessIpControl = CompatibleUtil.isSupportAccessIpControl(serverInfo);
+        if (!isSupportAccessIpControl) {
+            length = length - 2;
+        }
+        String copy[][] = new String[length][];
+        int j = 0;
+        for (int i = 0; i < dbAdvancedParameters.length; i++) {
+            if (!isSupportNewDbPro
+                    && (dbAdvancedParameters[i][0].equals(ConfConstants.HA_NODE_LIST)
+                            || dbAdvancedParameters[i][0].equals(ConfConstants.HA_PORT_ID))) {
+                continue;
+            }
+            if (!isSupportAccessIpControl
+                    && (dbAdvancedParameters[i][0].equals(ConfConstants.ACCESS_IP_CONTROL)
+                            || dbAdvancedParameters[i][0].equals(
+                                    ConfConstants.ACCESS_IP_CONTROL_FILE))) {
+                continue;
+            }
+            copy[j] = (String[]) dbAdvancedParameters[i].clone();
+            if (serverInfo != null
+                    && dbAdvancedParameters[i][0].equals(INDEX_SCAN_OID_BUFFER_PAGES)) {
+                if (CompatibleUtil.isSupportIndexScanOIDBufferSize(serverInfo)) {
+                    copy[j][0] = INDEX_SCAN_OID_BUFFER_SIZE;
+                    copy[j][1] = "int(v>=64*1024)";
+                    copy[j][2] = "64*1024";
+                    copy[j][3] = PARAMETER_TYPE_SERVER;
+                } else {
+                    copy[j][1] = CompatibleUtil.getIndexScanOIDBufferPagesValueType(serverInfo);
+                }
 
-			} else if (serverInfo != null
-					&& dbAdvancedParameters[i][0].equals(HA_MODE)) {
-				copy[j][1] = CompatibleUtil.getHAModeValue(serverInfo);
-			}
-			j++;
-		}
-		return copy;
-	}
+            } else if (serverInfo != null && dbAdvancedParameters[i][0].equals(HA_MODE)) {
+                copy[j][1] = CompatibleUtil.getHAModeValue(serverInfo);
+            }
+            j++;
+        }
+        return copy;
+    }
 
-	//HA parameters
-	private static String[][] haConfParameters = {
-			{HAConfParaConstants.HA_MODE, "string(on|off|yes|no|replica)",
-					"off", PARAMETER_TYPE_SERVER },
-			{HAConfParaConstants.HA_NODE_LIST, "string", "",
-					PARAMETER_TYPE_SERVER },
-			{HAConfParaConstants.HA_PORT_ID, "int(v>=1024&&v<=65535)", "59901",
-					PARAMETER_TYPE_SERVER },
-			{HA_REPLICA_LIST, "string", "", PARAMETER_TYPE_SERVER },
-			{HA_PING_HOSTS, "string", "", PARAMETER_TYPE_SERVER },
-			{HA_COPY_LOG_BASE, "string", "", PARAMETER_TYPE_SERVER },
-			{HA_DB_LIST, "string", "", PARAMETER_TYPE_SERVER },
-			{HA_APPLY_MAX_MEM_SIZE, "int", "0", PARAMETER_TYPE_SERVER },
-			{HA_COPY_SYNC_MODE, "string", "", PARAMETER_TYPE_SERVER },
-			{LOG_MAX_ARCHIVES, "int", "0", PARAMETER_TYPE_SERVER } };
+    // HA parameters
+    private static String[][] haConfParameters = {
+        {
+            HAConfParaConstants.HA_MODE,
+            "string(on|off|yes|no|replica)",
+            "off",
+            PARAMETER_TYPE_SERVER
+        },
+        {HAConfParaConstants.HA_NODE_LIST, "string", "", PARAMETER_TYPE_SERVER},
+        {HAConfParaConstants.HA_PORT_ID, "int(v>=1024&&v<=65535)", "59901", PARAMETER_TYPE_SERVER},
+        {HA_REPLICA_LIST, "string", "", PARAMETER_TYPE_SERVER},
+        {HA_PING_HOSTS, "string", "", PARAMETER_TYPE_SERVER},
+        {HA_COPY_LOG_BASE, "string", "", PARAMETER_TYPE_SERVER},
+        {HA_DB_LIST, "string", "", PARAMETER_TYPE_SERVER},
+        {HA_APPLY_MAX_MEM_SIZE, "int", "0", PARAMETER_TYPE_SERVER},
+        {HA_COPY_SYNC_MODE, "string", "", PARAMETER_TYPE_SERVER},
+        {LOG_MAX_ARCHIVES, "int", "0", PARAMETER_TYPE_SERVER}
+    };
 
-	/**
-	 * Get HA configuration parameters
-	 *
-	 * @return String[][]
-	 */
-	public static String[][] getHAConfParameters() {
-		String copy[][] = new String[haConfParameters.length][];
-		for (int i = 0; i < haConfParameters.length; i++) {
-			copy[i] = (String[]) haConfParameters[i].clone();
-		}
-		return copy;
-	}
+    /**
+     * Get HA configuration parameters
+     *
+     * @return String[][]
+     */
+    public static String[][] getHAConfParameters() {
+        String copy[][] = new String[haConfParameters.length][];
+        for (int i = 0; i < haConfParameters.length; i++) {
+            copy[i] = (String[]) haConfParameters[i].clone();
+        }
+        return copy;
+    }
 
-	//manager parameter
-	private static String[][] cmParameters = {{CM_PORT, "int", "8001" },
-			{MONITOR_INTERVAL, "int", "5" },
-			{ALLOW_USER_MULTI_CONNECTION, "string", "YES" },
-			{AUTO_START_BROKER, "string", "YES" },
-			{EXECUTE_DIAG, "string", "OFF" },
-			{SERVER_LONG_QUERY_TIME, "int", "10" },
-			{CM_TARGET, "string", "broker,server" } };
+    // manager parameter
+    private static String[][] cmParameters = {
+        {CM_PORT, "int", "8001"},
+        {MONITOR_INTERVAL, "int", "5"},
+        {ALLOW_USER_MULTI_CONNECTION, "string", "YES"},
+        {AUTO_START_BROKER, "string", "YES"},
+        {EXECUTE_DIAG, "string", "OFF"},
+        {SERVER_LONG_QUERY_TIME, "int", "10"},
+        {CM_TARGET, "string", "broker,server"}
+    };
 
-	/**
-	 * Get the static field cmParameters
-	 *
-	 * @return String[][]
-	 */
-	public static String[][] getCmParameters() {
-		String copy[][] = new String[cmParameters.length][];
-		for (int i = 0; i < cmParameters.length; i++) {
-			copy[i] = (String[]) cmParameters[i].clone();
-		}
-		return copy;
-	}
+    /**
+     * Get the static field cmParameters
+     *
+     * @return String[][]
+     */
+    public static String[][] getCmParameters() {
+        String copy[][] = new String[cmParameters.length][];
+        for (int i = 0; i < cmParameters.length; i++) {
+            copy[i] = (String[]) cmParameters[i].clone();
+        }
+        return copy;
+    }
 
-	//broker parameter
-	public static String[][] brokerParameters = {
-			{MASTER_SHM_ID, "int", "30001", PARAMETER_TYPE_BROKER_GENERAL },
-			{ADMIN_LOG_FILE, "string", "log/broker/cubrid_broker.log",
-					PARAMETER_TYPE_BROKER_GENERAL },
-			{ENABLE_ACCESS_CONTROL, "string(ON|OFF)", "",
-					PARAMETER_TYPE_BROKER_GENERAL },
-			{ACCESS_CONTROL_FILE, "string", "", PARAMETER_TYPE_BROKER_GENERAL },
-			{SERVICE, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_COMMON },
-			{BROKER_PORT, "int(1024~65535)", "", PARAMETER_TYPE_BROKER_COMMON },
-			{MIN_NUM_APPL_SERVER, "int", "5", PARAMETER_TYPE_BROKER_COMMON },
-			{MAX_NUM_APPL_SERVER, "int", "40", PARAMETER_TYPE_BROKER_COMMON },
-			{APPL_SERVER_SHM_ID, "int(1024~65535)", "",
-					PARAMETER_TYPE_BROKER_COMMON },
-			//	{ APPL_SERVER_MAX_SIZE, "int", "20" },
-			{LOG_DIR, "string", "log/broker/sql_log",
-					PARAMETER_TYPE_BROKER_COMMON },
-			{ERROR_LOG_DIR, "string", "log/broker/error_log",
-					PARAMETER_TYPE_BROKER_COMMON },
-			{SQL_LOG, "string(ON|OFF|ERROR|NOTICE|TIMEOUT)", "ON",
-					PARAMETER_TYPE_BROKER_COMMON },
-			{TIME_TO_KILL, "int", "120", PARAMETER_TYPE_BROKER_COMMON },
-			{SESSION_TIMEOUT, "int", "300", PARAMETER_TYPE_BROKER_COMMON },
-			{KEEP_CONNECTION, "string(ON|OFF|AUTO)", "AUTO",
-					PARAMETER_TYPE_BROKER_COMMON },
+    // broker parameter
+    public static String[][] brokerParameters = {
+        {MASTER_SHM_ID, "int", "30001", PARAMETER_TYPE_BROKER_GENERAL},
+        {ADMIN_LOG_FILE, "string", "log/broker/cubrid_broker.log", PARAMETER_TYPE_BROKER_GENERAL},
+        {ENABLE_ACCESS_CONTROL, "string(ON|OFF)", "", PARAMETER_TYPE_BROKER_GENERAL},
+        {ACCESS_CONTROL_FILE, "string", "", PARAMETER_TYPE_BROKER_GENERAL},
+        {SERVICE, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_COMMON},
+        {BROKER_PORT, "int(1024~65535)", "", PARAMETER_TYPE_BROKER_COMMON},
+        {MIN_NUM_APPL_SERVER, "int", "5", PARAMETER_TYPE_BROKER_COMMON},
+        {MAX_NUM_APPL_SERVER, "int", "40", PARAMETER_TYPE_BROKER_COMMON},
+        {APPL_SERVER_SHM_ID, "int(1024~65535)", "", PARAMETER_TYPE_BROKER_COMMON},
+        //	{ APPL_SERVER_MAX_SIZE, "int", "20" },
+        {LOG_DIR, "string", "log/broker/sql_log", PARAMETER_TYPE_BROKER_COMMON},
+        {ERROR_LOG_DIR, "string", "log/broker/error_log", PARAMETER_TYPE_BROKER_COMMON},
+        {SQL_LOG, "string(ON|OFF|ERROR|NOTICE|TIMEOUT)", "ON", PARAMETER_TYPE_BROKER_COMMON},
+        {TIME_TO_KILL, "int", "120", PARAMETER_TYPE_BROKER_COMMON},
+        {SESSION_TIMEOUT, "int", "300", PARAMETER_TYPE_BROKER_COMMON},
+        {KEEP_CONNECTION, "string(ON|OFF|AUTO)", "AUTO", PARAMETER_TYPE_BROKER_COMMON},
+        {STATEMENT_POOLING, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_ADVANCE},
+        {LONG_QUERY_TIME, "int", "60", PARAMETER_TYPE_BROKER_ADVANCE},
+        {LONG_TRANSACTION_TIME, "int", "60", PARAMETER_TYPE_BROKER_ADVANCE},
+        {SQL_LOG_MAX_SIZE, "int", "100000", PARAMETER_TYPE_BROKER_ADVANCE},
+        {LOG_BACKUP, "string(ON|OFF)", "OFF", PARAMETER_TYPE_BROKER_ADVANCE},
+        {SOURCE_ENV, "string", "cubrid.env", PARAMETER_TYPE_BROKER_ADVANCE},
+        {MAX_STRING_LENGTH, "int", "-1", PARAMETER_TYPE_BROKER_ADVANCE},
+        {APPL_SERVER_PORT, "int", "", PARAMETER_TYPE_BROKER_ADVANCE},
+        //	{ APPL_SERVER, "string(CAS)", "CAS" },
+        {ACCESS_LOG, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_ADVANCE},
+        {ACCESS_LIST, "string", "", PARAMETER_TYPE_BROKER_ADVANCE},
+        {CCI_PCONNECT, "string(ON|OFF)", "OFF", PARAMETER_TYPE_BROKER_ADVANCE},
+        {SELECT_AUTO_COMMIT, "string(ON|OFF)", "OFF", PARAMETER_TYPE_BROKER_ADVANCE},
+        {ACCESS_MODE, "string(RW|RO|SO)", "RW", PARAMETER_TYPE_BROKER_ADVANCE},
+        {PREFERRED_HOSTS, "string", "", PARAMETER_TYPE_BROKER_ADVANCE},
+        {CCI_DEFAULT_AUTOCOMMIT, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_ADVANCE},
+        {ENABLE_OPENSSL, "string(ON|OFF)", "OFF", PARAMETER_TYPE_BROKER_ADVANCE}
+    };
 
-			{STATEMENT_POOLING, "string(ON|OFF)", "ON",
-					PARAMETER_TYPE_BROKER_ADVANCE },
-			{LONG_QUERY_TIME, "int", "60", PARAMETER_TYPE_BROKER_ADVANCE },
-			{LONG_TRANSACTION_TIME, "int", "60", PARAMETER_TYPE_BROKER_ADVANCE },
-			{SQL_LOG_MAX_SIZE, "int", "100000", PARAMETER_TYPE_BROKER_ADVANCE },
-			{LOG_BACKUP, "string(ON|OFF)", "OFF", PARAMETER_TYPE_BROKER_ADVANCE },
-			{SOURCE_ENV, "string", "cubrid.env", PARAMETER_TYPE_BROKER_ADVANCE },
-			{MAX_STRING_LENGTH, "int", "-1", PARAMETER_TYPE_BROKER_ADVANCE },
-			{APPL_SERVER_PORT, "int", "", PARAMETER_TYPE_BROKER_ADVANCE },
-			//	{ APPL_SERVER, "string(CAS)", "CAS" },
-			{ACCESS_LOG, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_ADVANCE },
-			{ACCESS_LIST, "string", "", PARAMETER_TYPE_BROKER_ADVANCE },
-			{CCI_PCONNECT, "string(ON|OFF)", "OFF",
-					PARAMETER_TYPE_BROKER_ADVANCE },
-			{SELECT_AUTO_COMMIT, "string(ON|OFF)", "OFF",
-					PARAMETER_TYPE_BROKER_ADVANCE },
-			{ACCESS_MODE, "string(RW|RO|SO)", "RW",
-					PARAMETER_TYPE_BROKER_ADVANCE },
-			{PREFERRED_HOSTS, "string", "", PARAMETER_TYPE_BROKER_ADVANCE },
-            {CCI_DEFAULT_AUTOCOMMIT, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_ADVANCE },
-            {ENABLE_OPENSSL, "string(ON|OFF)", "OFF", PARAMETER_TYPE_BROKER_ADVANCE }};
+    /**
+     * Get the static field brokerParameters
+     *
+     * @param serverInfo ServerInfo
+     * @return String[][]
+     */
+    public static String[][] getBrokerParameters(ServerInfo serverInfo) {
+        int length = brokerParameters.length;
+        boolean isSupportNewBrokerParamProperty =
+                CompatibleUtil.isSupportNewBrokerParamPropery1(serverInfo);
+        boolean isSupportNewHAParam = CompatibleUtil.isSupportNewHABrokerParam(serverInfo);
+        boolean isSupportEnableAccessControl =
+                CompatibleUtil.isSupportEnableAccessControl(serverInfo);
+        boolean isSupportEnableOpenSSL = CompatibleUtil.isSupportEnableOpenSSL(serverInfo);
+        boolean isSupportCCIDefaultAutocommit =
+                CompatibleUtil.isSupportCCIDefaultAutocommit(serverInfo);
 
-	/**
-	 * Get the static field brokerParameters
-	 *
-	 * @param serverInfo ServerInfo
-	 * @return String[][]
-	 */
-	public static String[][] getBrokerParameters(ServerInfo serverInfo) {
-		int length = brokerParameters.length;
-		boolean isSupportNewBrokerParamProperty = CompatibleUtil.isSupportNewBrokerParamPropery1(serverInfo);
-		boolean isSupportNewHAParam = CompatibleUtil.isSupportNewHABrokerParam(serverInfo);
-		boolean isSupportEnableAccessControl = CompatibleUtil.isSupportEnableAccessControl(serverInfo);
-		boolean isSupportEnableOpenSSL = CompatibleUtil.isSupportEnableOpenSSL(serverInfo);
-		boolean isSupportCCIDefaultAutocommit = CompatibleUtil.isSupportCCIDefaultAutocommit(serverInfo);
-
-		if (!isSupportNewBrokerParamProperty) {
-			length = length - 3;
-		}
-		if (!isSupportNewHAParam) {
-			length = length - 1;
-		}
-		if (!isSupportEnableAccessControl) {
-			length = length - 2;
-		}
-		if (!isSupportEnableOpenSSL) {
+        if (!isSupportNewBrokerParamProperty) {
+            length = length - 3;
+        }
+        if (!isSupportNewHAParam) {
             length = length - 1;
         }
-		if (!isSupportCCIDefaultAutocommit) {
+        if (!isSupportEnableAccessControl) {
+            length = length - 2;
+        }
+        if (!isSupportEnableOpenSSL) {
             length = length - 1;
         }
-		String copy[][] = new String[length][];
-		int j = 0;
-		for (int i = 0; i < brokerParameters.length; i++) {
-			if (!isSupportNewBrokerParamProperty
-					&& (brokerParameters[i][0].equals(ConfConstants.CCI_PCONNECT)
-							|| brokerParameters[i][0].equals(ConfConstants.SELECT_AUTO_COMMIT) || brokerParameters[i][0].equals(ConfConstants.ACCESS_MODE))) {
-				continue;
-			}
-			if (!isSupportNewHAParam
-					&& (brokerParameters[i][0].equals(ConfConstants.PREFERRED_HOSTS))) {
-				continue;
-			}
-			if (!isSupportEnableAccessControl
-					&& (brokerParameters[i][0].equals(ENABLE_ACCESS_CONTROL) || brokerParameters[i][0].equals(ACCESS_CONTROL_FILE))) {
-				continue;
-			}
-			if (!isSupportEnableOpenSSL
+        if (!isSupportCCIDefaultAutocommit) {
+            length = length - 1;
+        }
+        String copy[][] = new String[length][];
+        int j = 0;
+        for (int i = 0; i < brokerParameters.length; i++) {
+            if (!isSupportNewBrokerParamProperty
+                    && (brokerParameters[i][0].equals(ConfConstants.CCI_PCONNECT)
+                            || brokerParameters[i][0].equals(ConfConstants.SELECT_AUTO_COMMIT)
+                            || brokerParameters[i][0].equals(ConfConstants.ACCESS_MODE))) {
+                continue;
+            }
+            if (!isSupportNewHAParam
+                    && (brokerParameters[i][0].equals(ConfConstants.PREFERRED_HOSTS))) {
+                continue;
+            }
+            if (!isSupportEnableAccessControl
+                    && (brokerParameters[i][0].equals(ENABLE_ACCESS_CONTROL)
+                            || brokerParameters[i][0].equals(ACCESS_CONTROL_FILE))) {
+                continue;
+            }
+            if (!isSupportEnableOpenSSL
                     && (brokerParameters[i][0].equals(ConfConstants.ENABLE_OPENSSL))) {
                 continue;
             }
-			if (!isSupportCCIDefaultAutocommit
+            if (!isSupportCCIDefaultAutocommit
                     && (brokerParameters[i][0].equals(ConfConstants.CCI_DEFAULT_AUTOCOMMIT))) {
                 continue;
             }
 
-			copy[j] = (String[]) brokerParameters[i].clone();
-			if (serverInfo != null
-					&& brokerParameters[i][0].equals(ACCESS_MODE)) {
-				copy[j][1] = CompatibleUtil.getBrokerAccessModeValue(serverInfo);
-			}
-			j++;
-		}
-		return copy;
-	}
+            copy[j] = (String[]) brokerParameters[i].clone();
+            if (serverInfo != null && brokerParameters[i][0].equals(ACCESS_MODE)) {
+                copy[j][1] = CompatibleUtil.getBrokerAccessModeValue(serverInfo);
+            }
+            j++;
+        }
+        return copy;
+    }
 
-	/**
-	 * Judge whether is default broker parameter
-	 *
-	 * @param param the String
-	 * @return boolean
-	 */
-	public static boolean isDefaultBrokerParameter(String param) { // FIXME more simple
-		if (APPL_SERVER_PORT.equals(param)) {
-			return true;
-		} else if (ACCESS_LIST.equals(param)) {
-			return true;
-		} else if (ACCESS_LOG.equals(param)) {
-			return true;
-		} else if (LOG_BACKUP.equals(param)) {
-			return true;
-		} else if (SQL_LOG_MAX_SIZE.equals(param)) {
-			return true;
-		} else if (MAX_STRING_LENGTH.equals(param)) {
-			return true;
-		} else if (SOURCE_ENV.equals(param)) {
-			return true;
-		} else if (STATEMENT_POOLING.equals(param)) {
-			return true;
-		} else if (LONG_QUERY_TIME.equals(param)) {
-			return true;
-		} else if (LONG_TRANSACTION_TIME.equals(param)) {
-			return true;
-		} else if (CCI_PCONNECT.equals(param)) {
-			return true;
-		} else if (SELECT_AUTO_COMMIT.equals(param)) {
-			return true;
-		} else if (ACCESS_MODE.equals(param)) {
-			return true;
-		} else if (PREFERRED_HOSTS.equals(param)) {
-			return true;
-		}
-		return false;
+    /**
+     * Judge whether is default broker parameter
+     *
+     * @param param the String
+     * @return boolean
+     */
+    public static boolean isDefaultBrokerParameter(String param) { // FIXME more simple
+        if (APPL_SERVER_PORT.equals(param)) {
+            return true;
+        } else if (ACCESS_LIST.equals(param)) {
+            return true;
+        } else if (ACCESS_LOG.equals(param)) {
+            return true;
+        } else if (LOG_BACKUP.equals(param)) {
+            return true;
+        } else if (SQL_LOG_MAX_SIZE.equals(param)) {
+            return true;
+        } else if (MAX_STRING_LENGTH.equals(param)) {
+            return true;
+        } else if (SOURCE_ENV.equals(param)) {
+            return true;
+        } else if (STATEMENT_POOLING.equals(param)) {
+            return true;
+        } else if (LONG_QUERY_TIME.equals(param)) {
+            return true;
+        } else if (LONG_TRANSACTION_TIME.equals(param)) {
+            return true;
+        } else if (CCI_PCONNECT.equals(param)) {
+            return true;
+        } else if (SELECT_AUTO_COMMIT.equals(param)) {
+            return true;
+        } else if (ACCESS_MODE.equals(param)) {
+            return true;
+        } else if (PREFERRED_HOSTS.equals(param)) {
+            return true;
+        }
+        return false;
+    }
 
-	}
-
-	private ConfConstants() {
-
-	}
+    private ConfConstants() {}
 }

--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/ConfConstants.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/ConfConstants.java
@@ -310,7 +310,9 @@ public final class ConfConstants implements
 					PARAMETER_TYPE_BROKER_ADVANCE },
 			{ACCESS_MODE, "string(RW|RO|SO)", "RW",
 					PARAMETER_TYPE_BROKER_ADVANCE },
-			{PREFERRED_HOSTS, "string", "", PARAMETER_TYPE_BROKER_ADVANCE } };
+			{PREFERRED_HOSTS, "string", "", PARAMETER_TYPE_BROKER_ADVANCE },
+            {CCI_DEFAULT_AUTOCOMMIT, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_ADVANCE },
+            {ENABLE_OPENSSL, "string(ON|OFF)", "OFF", PARAMETER_TYPE_BROKER_ADVANCE }};
 
 	/**
 	 * Get the static field brokerParameters
@@ -323,6 +325,9 @@ public final class ConfConstants implements
 		boolean isSupportNewBrokerParamProperty = CompatibleUtil.isSupportNewBrokerParamPropery1(serverInfo);
 		boolean isSupportNewHAParam = CompatibleUtil.isSupportNewHABrokerParam(serverInfo);
 		boolean isSupportEnableAccessControl = CompatibleUtil.isSupportEnableAccessControl(serverInfo);
+		boolean isSupportEnableOpenSSL = CompatibleUtil.isSupportEnableOpenSSL(serverInfo);
+		boolean isSupportCCIDefaultAutocommit = CompatibleUtil.isSupportCCIDefaultAutocommit(serverInfo);
+
 		if (!isSupportNewBrokerParamProperty) {
 			length = length - 3;
 		}
@@ -332,6 +337,12 @@ public final class ConfConstants implements
 		if (!isSupportEnableAccessControl) {
 			length = length - 2;
 		}
+		if (!isSupportEnableOpenSSL) {
+            length = length - 1;
+        }
+		if (!isSupportCCIDefaultAutocommit) {
+            length = length - 1;
+        }
 		String copy[][] = new String[length][];
 		int j = 0;
 		for (int i = 0; i < brokerParameters.length; i++) {
@@ -348,6 +359,15 @@ public final class ConfConstants implements
 					&& (brokerParameters[i][0].equals(ENABLE_ACCESS_CONTROL) || brokerParameters[i][0].equals(ACCESS_CONTROL_FILE))) {
 				continue;
 			}
+			if (!isSupportEnableOpenSSL
+                    && (brokerParameters[i][0].equals(ConfConstants.ENABLE_OPENSSL))) {
+                continue;
+            }
+			if (!isSupportCCIDefaultAutocommit
+                    && (brokerParameters[i][0].equals(ConfConstants.CCI_DEFAULT_AUTOCOMMIT))) {
+                continue;
+            }
+
 			copy[j] = (String[]) brokerParameters[i].clone();
 			if (serverInfo != null
 					&& brokerParameters[i][0].equals(ACCESS_MODE)) {

--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/CubridBrokerConfParaConstants.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/CubridBrokerConfParaConstants.java
@@ -72,6 +72,7 @@ public interface CubridBrokerConfParaConstants { //NOPMD
 	public final static String LONG_QUERY_TIME = "LONG_QUERY_TIME";
 	public final static String LONG_TRANSACTION_TIME = "LONG_TRANSACTION_TIME";
 	public final static String CCI_DEFAULT_AUTOCOMMIT = "CCI_DEFAULT_AUTOCOMMIT";
+	public final static String ENABLE_OPENSSL = "SSL";
 
 	public final static String PARAMETER_TYPE_BROKER_GENERAL = "general";
 	public final static String PARAMETER_TYPE_BROKER_COMMON = "common";
@@ -182,8 +183,15 @@ public interface CubridBrokerConfParaConstants { //NOPMD
 					"" },
 
 			{PREFERRED_HOSTS, "string", "", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.4.0&&os=linux", "false", "" }
+					"version>=8.4.0&&os=linux", "false", "" },
 
+            {CCI_DEFAULT_AUTOCOMMIT, "string(ON|OFF)", "ON",
+				    PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.4.1", "false",
+                    "" },
+
+            {ENABLE_OPENSSL, "string(ON|OFF)", "OFF",
+                    PARAMETER_TYPE_BROKER_ADVANCE, "version>=10.2.1", "false",
+                    "" }
 	};
 
 }

--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/CubridBrokerConfParaConstants.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/common/model/CubridBrokerConfParaConstants.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009 Search Solution Corporation. All rights reserved by Search
  * Solution.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met: -
  * Redistributions of source code must retain the above copyright notice, this
@@ -11,7 +11,7 @@
  * with the distribution. - Neither the name of the <ORGANIZATION> nor the names
  * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -23,175 +23,354 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
 package com.cubrid.cubridmanager.core.common.model;
 
 /**
- * 
  * cubrid_broker.conf configuration file parameters constants
- * 
+ *
  * @author pangqiren
  * @version 1.0 - 2011-9-7 created by pangqiren
  */
-public interface CubridBrokerConfParaConstants { //NOPMD
+public interface CubridBrokerConfParaConstants { // NOPMD
 
-	//broker parameter
-	public final static String BROKER_SECTION = "[broker]";
-	public final static String BROKER_SECTION_NAME = "broker";
+    // broker parameter
+    public static final String BROKER_SECTION = "[broker]";
+    public static final String BROKER_SECTION_NAME = "broker";
 
-	public final static String MASTER_SHM_ID = "MASTER_SHM_ID";
-	public final static String ADMIN_LOG_FILE = "ADMIN_LOG_FILE";
-	public final static String ENABLE_ACCESS_CONTROL = "ENABLE_ACCESS_CONTROL";
-	public final static String ACCESS_CONTROL_FILE = "ACCESS_CONTROL_FILE";
-	public final static String SERVICE = "SERVICE";
-	public final static String BROKER_PORT = "BROKER_PORT";
-	public final static String MIN_NUM_APPL_SERVER = "MIN_NUM_APPL_SERVER";
-	public final static String MAX_NUM_APPL_SERVER = "MAX_NUM_APPL_SERVER";
-	public final static String APPL_SERVER_SHM_ID = "APPL_SERVER_SHM_ID";
-	public final static String APPL_SERVER_MAX_SIZE = "APPL_SERVER_MAX_SIZE";
-	public final static String LOG_DIR = "LOG_DIR";
-	public final static String ERROR_LOG_DIR = "ERROR_LOG_DIR";
-	public final static String SQL_LOG = "SQL_LOG";
-	public final static String TIME_TO_KILL = "TIME_TO_KILL";
-	public final static String SESSION_TIMEOUT = "SESSION_TIMEOUT";
-	public final static String KEEP_CONNECTION = "KEEP_CONNECTION";
-	public final static String ACCESS_LIST = "ACCESS_LIST";
-	public final static String ACCESS_LOG = "ACCESS_LOG";
-	public final static String APPL_SERVER_PORT = "APPL_SERVER_PORT";
-	public final static String CCI_PCONNECT = "CCI_PCONNECT";
-	public final static String SELECT_AUTO_COMMIT = "SELECT_AUTO_COMMIT";
-	public final static String ACCESS_MODE = "ACCESS_MODE";
-	public final static String PREFERRED_HOSTS = "PREFERRED_HOSTS";
-	public final static String APPL_SERVER = "APPL_SERVER";
-	public final static String LOG_BACKUP = "LOG_BACKUP";
-	public final static String SQL_LOG_MAX_SIZE = "SQL_LOG_MAX_SIZE";
-	public final static String MAX_STRING_LENGTH = "MAX_STRING_LENGTH";
-	public final static String SOURCE_ENV = "SOURCE_ENV";
-	public final static String STATEMENT_POOLING = "STATEMENT_POOLING";
-	public final static String LONG_QUERY_TIME = "LONG_QUERY_TIME";
-	public final static String LONG_TRANSACTION_TIME = "LONG_TRANSACTION_TIME";
-	public final static String CCI_DEFAULT_AUTOCOMMIT = "CCI_DEFAULT_AUTOCOMMIT";
-	public final static String ENABLE_OPENSSL = "SSL";
+    public static final String MASTER_SHM_ID = "MASTER_SHM_ID";
+    public static final String ADMIN_LOG_FILE = "ADMIN_LOG_FILE";
+    public static final String ENABLE_ACCESS_CONTROL = "ENABLE_ACCESS_CONTROL";
+    public static final String ACCESS_CONTROL_FILE = "ACCESS_CONTROL_FILE";
+    public static final String SERVICE = "SERVICE";
+    public static final String BROKER_PORT = "BROKER_PORT";
+    public static final String MIN_NUM_APPL_SERVER = "MIN_NUM_APPL_SERVER";
+    public static final String MAX_NUM_APPL_SERVER = "MAX_NUM_APPL_SERVER";
+    public static final String APPL_SERVER_SHM_ID = "APPL_SERVER_SHM_ID";
+    public static final String APPL_SERVER_MAX_SIZE = "APPL_SERVER_MAX_SIZE";
+    public static final String LOG_DIR = "LOG_DIR";
+    public static final String ERROR_LOG_DIR = "ERROR_LOG_DIR";
+    public static final String SQL_LOG = "SQL_LOG";
+    public static final String TIME_TO_KILL = "TIME_TO_KILL";
+    public static final String SESSION_TIMEOUT = "SESSION_TIMEOUT";
+    public static final String KEEP_CONNECTION = "KEEP_CONNECTION";
+    public static final String ACCESS_LIST = "ACCESS_LIST";
+    public static final String ACCESS_LOG = "ACCESS_LOG";
+    public static final String APPL_SERVER_PORT = "APPL_SERVER_PORT";
+    public static final String CCI_PCONNECT = "CCI_PCONNECT";
+    public static final String SELECT_AUTO_COMMIT = "SELECT_AUTO_COMMIT";
+    public static final String ACCESS_MODE = "ACCESS_MODE";
+    public static final String PREFERRED_HOSTS = "PREFERRED_HOSTS";
+    public static final String APPL_SERVER = "APPL_SERVER";
+    public static final String LOG_BACKUP = "LOG_BACKUP";
+    public static final String SQL_LOG_MAX_SIZE = "SQL_LOG_MAX_SIZE";
+    public static final String MAX_STRING_LENGTH = "MAX_STRING_LENGTH";
+    public static final String SOURCE_ENV = "SOURCE_ENV";
+    public static final String STATEMENT_POOLING = "STATEMENT_POOLING";
+    public static final String LONG_QUERY_TIME = "LONG_QUERY_TIME";
+    public static final String LONG_TRANSACTION_TIME = "LONG_TRANSACTION_TIME";
+    public static final String CCI_DEFAULT_AUTOCOMMIT = "CCI_DEFAULT_AUTOCOMMIT";
+    public static final String ENABLE_OPENSSL = "SSL";
 
-	public final static String PARAMETER_TYPE_BROKER_GENERAL = "general";
-	public final static String PARAMETER_TYPE_BROKER_COMMON = "common";
-	public final static String PARAMETER_TYPE_BROKER_ADVANCE = "advance";
+    public static final String PARAMETER_TYPE_BROKER_GENERAL = "general";
+    public static final String PARAMETER_TYPE_BROKER_COMMON = "common";
+    public static final String PARAMETER_TYPE_BROKER_ADVANCE = "advance";
 
-	public final static String[][] BROKER_CONF_PARAS_IN_COMMON = {
-			{MASTER_SHM_ID, "int(v>0)", "30001", PARAMETER_TYPE_BROKER_GENERAL,
-					"version>=8.2.0", "false", "" },
+    public static final String[][] BROKER_CONF_PARAS_IN_COMMON = {
+        {
+            MASTER_SHM_ID,
+            "int(v>0)",
+            "30001",
+            PARAMETER_TYPE_BROKER_GENERAL,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            ADMIN_LOG_FILE,
+            "string",
+            "log/broker/cubrid_broker.log",
+            PARAMETER_TYPE_BROKER_GENERAL,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            ENABLE_ACCESS_CONTROL,
+            "string(ON|OFF)",
+            "",
+            PARAMETER_TYPE_BROKER_GENERAL,
+            "version>=8.4.0",
+            "false",
+            ""
+        },
+        {
+            ACCESS_CONTROL_FILE,
+            "string",
+            "",
+            PARAMETER_TYPE_BROKER_GENERAL,
+            "version>=8.4.0",
+            "false",
+            ""
+        }
+    };
 
-			{ADMIN_LOG_FILE, "string", "log/broker/cubrid_broker.log",
-					PARAMETER_TYPE_BROKER_GENERAL, "version>=8.2.0", "false",
-					"" },
-			{ENABLE_ACCESS_CONTROL, "string(ON|OFF)", "",
-					PARAMETER_TYPE_BROKER_GENERAL, "version>=8.4.0", "false",
-					"" },
-
-			{ACCESS_CONTROL_FILE, "string", "", PARAMETER_TYPE_BROKER_GENERAL,
-					"version>=8.4.0", "false", "" } };
-
-	//broker parameter
-	public final static String[][] BROKER_CONF_PARAS_IN_BROKER = {
-
-			{SERVICE, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_COMMON,
-					"version>=8.2.0", "false", "" },
-
-			{BROKER_PORT, "int(v>=1024&&v<=65535)", "30000",
-					PARAMETER_TYPE_BROKER_COMMON, "version>=8.4.0", "false", "" },
-
-			{MIN_NUM_APPL_SERVER, "int", "5", PARAMETER_TYPE_BROKER_COMMON,
-					"version>=8.2.0", "false", "" },
-
-			{MAX_NUM_APPL_SERVER, "int", "40", PARAMETER_TYPE_BROKER_COMMON,
-					"version>=8.2.0", "false", "" },
-
-			{APPL_SERVER_SHM_ID, "int(v>=1024&&v<=65535)", "30000",
-					PARAMETER_TYPE_BROKER_COMMON, "version>=8.2.0", "false", "" },
-
-			{APPL_SERVER_MAX_SIZE, "int", "40", PARAMETER_TYPE_BROKER_COMMON,
-					"version>=8.2.0", "false", "" },
-
-			{LOG_DIR, "string", "log/broker/sql_log",
-					PARAMETER_TYPE_BROKER_COMMON, "version>=8.2.0", "false", "" },
-
-			{ERROR_LOG_DIR, "string", "log/broker/error_log",
-					PARAMETER_TYPE_BROKER_COMMON, "version>=8.2.0", "false", "" },
-
-			{SQL_LOG, "string(ON|OFF|ERROR|NOTICE|TIMEOUT)", "ON",
-					PARAMETER_TYPE_BROKER_COMMON, "version>=8.2.0", "false", "" },
-
-			{TIME_TO_KILL, "int(v>0(", "120", PARAMETER_TYPE_BROKER_COMMON,
-					"version>=8.2.0", "false", "" },
-
-			{SESSION_TIMEOUT, "int", "300", PARAMETER_TYPE_BROKER_COMMON,
-					"version>=8.2.0", "false", "" },
-
-			{KEEP_CONNECTION, "string(ON|OFF|AUTO)", "AUTO",
-					PARAMETER_TYPE_BROKER_COMMON, "version>=8.2.0", "false", "" },
-
-			{ACCESS_LIST, "string", "", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{ACCESS_LOG, "string(ON|OFF)", "ON", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{APPL_SERVER_PORT, "int", "", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{APPL_SERVER, "string(CAS)", "CAS", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{LOG_BACKUP, "string(ON|OFF)", "OFF",
-					PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.2.0", "false",
-					"" },
-
-			{SQL_LOG_MAX_SIZE, "int", "100000", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{MAX_STRING_LENGTH, "int", "-1", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{SOURCE_ENV, "string", "cubrid.env", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{STATEMENT_POOLING, "string(ON|OFF)", "ON",
-					PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.2.0", "false",
-					"" },
-
-			{CCI_PCONNECT, "string(ON|OFF)", "OFF",
-					PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.2.2", "false",
-					"" },
-
-			{LONG_QUERY_TIME, "int", "60", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{LONG_TRANSACTION_TIME, "int", "60", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.2.0", "false", "" },
-
-			{ACCESS_MODE, "string(RW|RO|SO)", "RW",
-					PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.2.2", "false",
-					"" },
-
-			{ACCESS_MODE, "string(RW|RO|SO|PHRO)", "RW",
-					PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.4.0&&os=linux",
-					"false", "" },
-
-			{SELECT_AUTO_COMMIT, "string(ON|OFF)", "OFF",
-					PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.2.2", "false",
-					"" },
-
-			{PREFERRED_HOSTS, "string", "", PARAMETER_TYPE_BROKER_ADVANCE,
-					"version>=8.4.0&&os=linux", "false", "" },
-
-            {CCI_DEFAULT_AUTOCOMMIT, "string(ON|OFF)", "ON",
-				    PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.4.1", "false",
-                    "" },
-
-            {ENABLE_OPENSSL, "string(ON|OFF)", "OFF",
-                    PARAMETER_TYPE_BROKER_ADVANCE, "version>=10.2.1", "false",
-                    "" }
-	};
-
+    // broker parameter
+    public static final String[][] BROKER_CONF_PARAS_IN_BROKER = {
+        {
+            SERVICE,
+            "string(ON|OFF)",
+            "ON",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            BROKER_PORT,
+            "int(v>=1024&&v<=65535)",
+            "30000",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.4.0",
+            "false",
+            ""
+        },
+        {
+            MIN_NUM_APPL_SERVER,
+            "int",
+            "5",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            MAX_NUM_APPL_SERVER,
+            "int",
+            "40",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            APPL_SERVER_SHM_ID,
+            "int(v>=1024&&v<=65535)",
+            "30000",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            APPL_SERVER_MAX_SIZE,
+            "int",
+            "40",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            LOG_DIR,
+            "string",
+            "log/broker/sql_log",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            ERROR_LOG_DIR,
+            "string",
+            "log/broker/error_log",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            SQL_LOG,
+            "string(ON|OFF|ERROR|NOTICE|TIMEOUT)",
+            "ON",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            TIME_TO_KILL,
+            "int(v>0(",
+            "120",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            SESSION_TIMEOUT,
+            "int",
+            "300",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            KEEP_CONNECTION,
+            "string(ON|OFF|AUTO)",
+            "AUTO",
+            PARAMETER_TYPE_BROKER_COMMON,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {ACCESS_LIST, "string", "", PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.2.0", "false", ""},
+        {
+            ACCESS_LOG,
+            "string(ON|OFF)",
+            "ON",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {APPL_SERVER_PORT, "int", "", PARAMETER_TYPE_BROKER_ADVANCE, "version>=8.2.0", "false", ""},
+        {
+            APPL_SERVER,
+            "string(CAS)",
+            "CAS",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            LOG_BACKUP,
+            "string(ON|OFF)",
+            "OFF",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            SQL_LOG_MAX_SIZE,
+            "int",
+            "100000",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            MAX_STRING_LENGTH,
+            "int",
+            "-1",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            SOURCE_ENV,
+            "string",
+            "cubrid.env",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            STATEMENT_POOLING,
+            "string(ON|OFF)",
+            "ON",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            CCI_PCONNECT,
+            "string(ON|OFF)",
+            "OFF",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.2",
+            "false",
+            ""
+        },
+        {
+            LONG_QUERY_TIME,
+            "int",
+            "60",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            LONG_TRANSACTION_TIME,
+            "int",
+            "60",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.0",
+            "false",
+            ""
+        },
+        {
+            ACCESS_MODE,
+            "string(RW|RO|SO)",
+            "RW",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.2",
+            "false",
+            ""
+        },
+        {
+            ACCESS_MODE,
+            "string(RW|RO|SO|PHRO)",
+            "RW",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.4.0&&os=linux",
+            "false",
+            ""
+        },
+        {
+            SELECT_AUTO_COMMIT,
+            "string(ON|OFF)",
+            "OFF",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.2.2",
+            "false",
+            ""
+        },
+        {
+            PREFERRED_HOSTS,
+            "string",
+            "",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.4.0&&os=linux",
+            "false",
+            ""
+        },
+        {
+            CCI_DEFAULT_AUTOCOMMIT,
+            "string(ON|OFF)",
+            "ON",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=8.4.1",
+            "false",
+            ""
+        },
+        {
+            ENABLE_OPENSSL,
+            "string(ON|OFF)",
+            "OFF",
+            PARAMETER_TYPE_BROKER_ADVANCE,
+            "version>=10.2.1",
+            "false",
+            ""
+        }
+    };
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4358

Purpose
for 11.1.0.0001 Release.

Implementation
- In Server 11.0.1 or more , 'ENABLE_ACCESS_CONTROL' option is not appended in cubrid_broker.conf
- In Server 10.2.1 or more , 'SSL' option is added in cubrid_broker.conf (default : OFF)
- In Server 8.4.1 or more , 'CCI_DEFAULT_AUTOCOMMIT' option is added in cubrid_broker.conf (default : ON)
- modify error for CUBRID site connection.

Remarks
N/A