### PR TITLE
[TOOLS-4437] When create or edit a table, error occurs if colum name contains uppercase characters

### DIFF
--- a/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
+++ b/com.cubrid.common.core/src/com/cubrid/common/core/util/QueryUtil.java
@@ -755,8 +755,9 @@ public final class QueryUtil {
 
 	private static String parseColumnDefinition(String createSql, String columnName) {
 		int index = 0;
+		String lowerColumnName = columnName.toLowerCase();
 
-		Pattern pattern = Pattern.compile(String.format("\\[%s\\].[\\w\\s\\d\\(\\,\\)\\.']*", columnName));
+		Pattern pattern = Pattern.compile(String.format("\\[%s\\].[\\w\\s\\d\\(\\,\\)\\.']*", lowerColumnName));
 		Matcher matcher = pattern.matcher(createSql);
 		matcher.find();
 		String data = matcher.group();


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4437

Purpose
RND Issue

Implementation
- Input column name is converted to lowercase to match the column name stored in the server.

Remark
For CM