### PR TITLE
[TOOLS-4457] When building, the version (commit-no) should be automatically updated.

### DIFF
--- a/com.cubrid.cubridmanager.build/build.sh
+++ b/com.cubrid.cubridmanager.build/build.sh
@@ -8,6 +8,25 @@ BUILD_HOME=${WORKSPACE}
 BUILD_DIR=${BUILD_HOME}/${PRODUCT_DIR}/com.cubrid.cubridmanager.build
 VERSION_DIR=${BUILD_HOME}/${PRODUCT_DIR}/com.cubrid.cubridmanager.ui
 VERSION_FILE_PATH=${VERSION_DIR}/version.properties
+
+echo "Version File Update.... (${VERSION_FILE_PATH})"
+
+if [ -d ${BUILD_HOME}/${PRODUCT_DIR}/.git ]; then
+  COMMIT_NUMBER=$(cd ${BUILD_HOME}/${PRODUCT_DIR} && git rev-list --count HEAD | awk '{ printf "%04d", $1 }' 2> /dev/null)
+  [ $? -ne 0 ] && COMMIT_NUMBER=$(cd ${BUILD_HOME}/${PRODUCT_DIR} && git log --oneline | wc -l)
+else
+  COMMIT_NUMBER=0000
+fi
+
+RELEASE_VERSION=$(cat ${VERSION_FILE_PATH} | grep releaseVersion | cut -d '=' -f2)
+
+echo "RELEASE_VERSION = " $RELEASE_VERSION
+echo "COMMIT_NUMBER = " $COMMIT_NUMBER
+FULL_VERSION=buildVersionId=${RELEASE_VERSION}.${COMMIT_NUMBER}
+
+sed -i '/buildVersionId/d' ${VERSION_FILE_PATH}
+echo $FULL_VERSION >> ${VERSION_FILE_PATH}
+
 VERSION=`grep buildVersionId ${VERSION_FILE_PATH} | awk 'BEGIN {FS="="} ; {print $2}'`
 CUR_VER_DIR=`date +%Y%m%d`
 CUR_VER_DIR=cubridadmin-deploy/${CUR_VER_DIR}_${VERSION}

--- a/com.cubrid.cubridmanager.build/build_other_env.sh
+++ b/com.cubrid.cubridmanager.build/build_other_env.sh
@@ -10,6 +10,25 @@ BUILD_HOME=${WORKSPACE}
 BUILD_DIR=${BUILD_HOME}/${PRODUCT_DIR}/com.cubrid.cubridmanager.build
 VERSION_DIR=${BUILD_HOME}/${PRODUCT_DIR}/com.cubrid.cubridmanager.ui
 VERSION_FILE_PATH=${VERSION_DIR}/version.properties
+
+echo "Version File Update.... (${VERSION_FILE_PATH})"
+
+if [ -d ${BUILD_HOME}/${PRODUCT_DIR}/.git ]; then
+  COMMIT_NUMBER=$(cd ${BUILD_HOME}/${PRODUCT_DIR} && git rev-list --count HEAD | awk '{ printf "%04d", $1 }' 2> /dev/null)
+  [ $? -ne 0 ] && COMMIT_NUMBER=$(cd ${BUILD_HOME}/${PRODUCT_DIR} && git log --oneline | wc -l)
+else
+  COMMIT_NUMBER=0000
+fi
+
+RELEASE_VERSION=$(cat ${VERSION_FILE_PATH} | grep releaseVersion | cut -d '=' -f2)
+
+echo "RELEASE_VERSION = " $RELEASE_VERSION
+echo "COMMIT_NUMBER = " $COMMIT_NUMBER
+FULL_VERSION=buildVersionId=${RELEASE_VERSION}.${COMMIT_NUMBER}
+
+sed -i '/buildVersionId/d' ${VERSION_FILE_PATH}
+echo $FULL_VERSION >> ${VERSION_FILE_PATH}
+
 VERSION=`grep buildVersionId ${VERSION_FILE_PATH} | awk 'BEGIN {FS="="} ; {print $2}'`
 CUR_VER_DIR=`date +%Y%m%d`
 CUR_VER_DIR=cubridadmin-deploy/${CUR_VER_DIR}_${VERSION}

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/Version.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/Version.java
@@ -41,7 +41,6 @@ public class Version extends NLS {
 		NLS.initializeMessages("version", Version.class);
 	}
 	public static String productName;
-	public static String releaseStr;
 	public static String releaseVersion;
 	public static String buildVersionId;
 }

--- a/com.cubrid.cubridmanager.ui/version.properties
+++ b/com.cubrid.cubridmanager.ui/version.properties
@@ -1,4 +1,3 @@
 productName=CUBRID Admin
-releaseStr=11.1.1
 releaseVersion=11.1.1
 

--- a/com.cubrid.cubridmanager.ui/version.properties
+++ b/com.cubrid.cubridmanager.ui/version.properties
@@ -1,4 +1,4 @@
 productName=CUBRID Admin
 releaseStr=11.1.1
 releaseVersion=11.1.1
-buildVersionId=11.1.1.0002
+


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4457

Purpose
Auto-update 'commit-no'

Implementation
- modify build scripts
- deleted buildVersionId in version file

Remarks
For CA