### PR TITLE
RenameSuggestion

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/navigator/GetSchemaDDLTask.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/navigator/GetSchemaDDLTask.java
@@ -140,7 +140,7 @@ public class GetSchemaDDLTask extends
 					// Get view column
 					GetViewAllColumnsTask getAllDBVclassTask = new GetViewAllColumnsTask(databaseInfo, connection);
 					getAllDBVclassTask.setClassName(schemaName);
-					getAllDBVclassTask.getAllVclassListTaskExcute();
+					getAllDBVclassTask.getAllVclassListTaskExecute();
 					// If failed
 					if (getAllDBVclassTask.getErrorMsg() != null || getAllDBVclassTask.isCancel()) {
 						errorMsg = getAllDBVclassTask.getErrorMsg();

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/compare/schema/control/TableSchemaCompareComposite.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/compare/schema/control/TableSchemaCompareComposite.java
@@ -250,7 +250,7 @@ public class TableSchemaCompareComposite extends
 				GetViewAllColumnsTask getAllDBVclassTask = new GetViewAllColumnsTask(
 						db.getDatabaseInfo());
 				getAllDBVclassTask.setClassName(tableName);
-				getAllDBVclassTask.getAllVclassListTaskExcute();
+				getAllDBVclassTask.getAllVclassListTaskExecute();
 
 				/*Get query list*/
 				List<String> vclassList = getAllDBVclassTask.getAllVclassList();

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/CreateViewDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/CreateViewDialog.java
@@ -777,7 +777,7 @@ public class CreateViewDialog extends
 					if (task instanceof GetAllClassListTask) {
 						((GetAllClassListTask) task).getClassInfoTaskExcute();
 					} else if (task instanceof GetViewAllColumnsTask) {
-						((GetViewAllColumnsTask) task).getAllVclassListTaskExcute();
+						((GetViewAllColumnsTask) task).getAllVclassListTaskExecute();
 					} else if (task instanceof GetAllAttrTask) {
 						((GetAllAttrTask) task).getAttrList();
 					} else {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/GetInfoDataTask.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/control/GetInfoDataTask.java
@@ -227,7 +227,7 @@ public class GetInfoDataTask extends JDBCTask {
 			GetViewAllColumnsTask getAllDBVclassTask = new GetViewAllColumnsTask(
 					schemaNode.getDatabase().getDatabaseInfo());
 			getAllDBVclassTask.setClassName(schemaNode.getName());
-			getAllDBVclassTask.getAllVclassListTaskExcute();
+			getAllDBVclassTask.getAllVclassListTaskExecute();
 
 			/*If failed*/
 			if (getAllDBVclassTask.getErrorMsg() != null || getAllDBVclassTask.isCancel()) {

--- a/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetViewAllColumnsTaskTest.java
+++ b/com.cubrid.cubridmanager.core.testfragment/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetViewAllColumnsTaskTest.java
@@ -42,12 +42,12 @@ public class GetViewAllColumnsTaskTest extends
 
 		GetViewAllColumnsTask task = new GetViewAllColumnsTask(databaseInfo);
 		task.setClassName("db_attribute");
-		task.getAllVclassListTaskExcute();
+		task.getAllVclassListTaskExecute();
 		List<String> allVclassList = task.getAllVclassList();
 		assert (allVclassList.contains("attr_name"));
 
-		task.getAllVclassListTaskExcute();
+		task.getAllVclassListTaskExecute();
 		task.setErrorMsg("error");
-		task.getAllVclassListTaskExcute();
+		task.getAllVclassListTaskExecute();
 	}
 }

--- a/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetViewAllColumnsTask.java
+++ b/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetViewAllColumnsTask.java
@@ -60,7 +60,7 @@ public class GetViewAllColumnsTask extends
 	 * 
 	 * Get all views class list and task execute
 	 */
-	public void getAllVclassListTaskExcute() {
+	public void getAllVclassListTaskExecute() {
 		allVclassList = new ArrayList<String>();
 		try {
 			if (errorMsg != null && errorMsg.trim().length() > 0) {


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:

```java
/* Non-descriptive Method Name in com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetViewAllColumnsTask.java */
    public void getAllVclassListTaskExcute() {
		allVclassList = new ArrayList<String>();
		try {
			if (errorMsg != null && errorMsg.trim().length() > 0) {
				return;
			}

			if (connection == null || connection.isClosed()) {
				errorMsg = Messages.error_getConnection;
				return;
			}

			String sql;
			if (databaseInfo.isSupportUserSchema()) {
				sql = "SELECT vclass_name, vclass_def FROM db_vclass WHERE CONCAT(owner_name, '.' , vclass_name)=?";
			}  else {
				sql = "SELECT vclass_name, vclass_def FROM db_vclass WHERE vclass_name=?";
			}

			// [TOOLS-2425]Support shard broker
			sql = databaseInfo.wrapShardQuery(sql);

			stmt = connection.prepareStatement(sql);
			((PreparedStatement) stmt).setString(1, className);
			rs = ((PreparedStatement) stmt).executeQuery();
			while (rs.next()) {
				String attrName = rs.getString("vclass_def");
				allVclassList.add(attrName);
			}
		} catch (SQLException e) {
			errorMsg = e.getMessage();
		} finally {
			finish();
		}
	}
```
We consider "getAllVclassListTaskExcute" as non-descriptive because it contains a typo, i.e., "Excute" should be "Execute". We have corrected it and submitted a pull request.


Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.