### PR TITLE
[TOOLS-4739] the entire screen is not displayed in Wizard and Dialog.

### DIFF
--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/AddQueryToFavoriteDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/AddQueryToFavoriteDialog.java
@@ -67,7 +67,7 @@ public class AddQueryToFavoriteDialog extends CMTitleAreaDialog {
 
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 240);
+        getShell().setMinimumSize(400, 240);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleSqlFavorite);
         setTitle(Messages.titleSqlFavoriteDetail);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/AssignEditorNameDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/AssignEditorNameDialog.java
@@ -101,7 +101,7 @@ public class AssignEditorNameDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(380, 220);
+        getShell().setMinimumSize(380, 220);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.shellAssignName);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/ExportConnectionDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/ExportConnectionDialog.java
@@ -250,7 +250,7 @@ public class ExportConnectionDialog extends CMTitleAreaDialog {
 
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(640, 480);
+        getShell().setMinimumSize(640, 480);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleExportConnection);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/ShardIdSelectionDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/dialog/ShardIdSelectionDialog.java
@@ -210,7 +210,7 @@ public class ShardIdSelectionDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        this.getShell().setSize(450, 250);
+        this.getShell().setMinimumSize(450, 250);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleChooseShardIdDialog);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/ShowDashboardDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/preference/ShowDashboardDialog.java
@@ -150,7 +150,7 @@ public class ShowDashboardDialog extends Dialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(380, 150);
+        getShell().setMinimumSize(380, 150);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleShowDashboard);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/common/sqlrunner/dialog/ViewSQLLogDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/common/sqlrunner/dialog/ViewSQLLogDialog.java
@@ -235,7 +235,7 @@ public class ViewSQLLogDialog extends TrayDialog {
     protected void constrainShellSize() {
         super.constrainShellSize();
         getShell().setText(Messages.titleViewSQLLog);
-        getShell().setSize(900, 600);
+        getShell().setMinimumSize(900, 600);
         CommonUITool.centerShell(getShell());
     }
 

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/compare/data/dialog/DataCompareDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/compare/data/dialog/DataCompareDialog.java
@@ -173,7 +173,7 @@ public class DataCompareDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(600, 400);
+        getShell().setMinimumSize(600, 400);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleDataComparison);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/compare/schema/dialog/SchemaCompareDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/compare/schema/dialog/SchemaCompareDialog.java
@@ -181,7 +181,7 @@ public class SchemaCompareDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(600, 400);
+        getShell().setMinimumSize(600, 400);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleSchemaComparison);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/serial/dialog/CreateOrEditSerialDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/serial/dialog/CreateOrEditSerialDialog.java
@@ -431,7 +431,7 @@ public class CreateOrEditSerialDialog extends CMTitleAreaDialog implements Modif
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(500, 600);
+        getShell().setMinimumSize(500, 600);
         CommonUITool.centerShell(getShell());
         if (editedNode == null) {
             getShell().setText(Messages.titleCreateSerialDialog);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/action/ExportWizardAction.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/action/ExportWizardAction.java
@@ -132,7 +132,7 @@ public class ExportWizardAction extends SelectionAction {
         }
         ExportDataWizardDialog dlg =
                 new ExportDataWizardDialog(getShell(), new ExportDataWizard(database, tableList));
-        dlg.setPageSize(800, Util.isMac() ? 480 : 455);
+        dlg.setPageSize(800, Util.isMac() ? 500 : 475);
         dlg.open();
     }
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddQueryDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddQueryDialog.java
@@ -134,7 +134,7 @@ public class AddQueryDialog extends CMTitleAreaDialog {
     /** @see com.cubrid.common.ui.spi.dialog.CMTitleAreaDialog#constrainShellSize() */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 480);
+        getShell().setMinimumSize(400, 480);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.msgAddQueryDialog);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddResolutionDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddResolutionDialog.java
@@ -205,7 +205,7 @@ public class AddResolutionDialog extends CMTitleAreaDialog implements ModifyList
     protected void constrainShellSize() {
         super.constrainShellSize();
         getShell().setText(Messages.titleTitleSetResolution);
-        getShell().setSize(500, 400);
+        getShell().setMinimumSize(500, 400);
     }
 
     /**

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/CreateLikeTableDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/CreateLikeTableDialog.java
@@ -183,7 +183,7 @@ public class CreateLikeTableDialog extends CMTitleAreaDialog implements ModifyLi
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(450, 240);
+        getShell().setMinimumSize(450, 240);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleCreateLikeTableDialog);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/CreateViewDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/CreateViewDialog.java
@@ -841,7 +841,7 @@ public class CreateViewDialog extends CMTitleAreaDialog {
 
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(600, 700);
+        getShell().setMinimumSize(600, 700);
         CommonUITool.centerShell(getShell());
     }
 

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/ImportDataFromFileDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/ImportDataFromFileDialog.java
@@ -122,7 +122,7 @@ public class ImportDataFromFileDialog extends PstmtDataDialog {
 
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setMinimumSize(640, 700);
+        getShell().setMinimumSize(640, 770);
     }
 
     /**

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportDataConfirmPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportDataConfirmPage.java
@@ -192,5 +192,7 @@ public class ExportDataConfirmPage extends ExportWizardPage {
             info.append(NEW_LINE);
         }
         infoTest.setText(info.toString().trim());
+        
+        getShell().setMinimumSize(800, 600);
     }
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingForLoadDBPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingForLoadDBPage.java
@@ -589,6 +589,8 @@ public class ExportSettingForLoadDBPage extends ExportWizardPage {
         fileCharsetCombo.select(index);
 
         updateDialogStatus();
+
+        getShell().setMinimumSize(820, 500);
     }
 
     /** load tables and columns */
@@ -874,6 +876,7 @@ public class ExportSettingForLoadDBPage extends ExportWizardPage {
             init();
             isFirstVisible = false;
         }
+        getShell().setMinimumSize(820, 500);
     }
 
     /**

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportSettingPage.java
@@ -1210,6 +1210,8 @@ public class ExportSettingPage extends ExportWizardPage {
             isFirstVisible = false;
         }
         updateDialogStatus(null);
+        
+        getShell().setMinimumSize(1000, 690);
     }
 
     /**

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportTypePage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/exp/ExportTypePage.java
@@ -309,6 +309,8 @@ public class ExportTypePage extends ExportWizardPage {
         historyCombo.setEnabled(false);
         renameButton.setEnabled(false);
         deleteButton.setEnabled(false);
+        
+        getShell().setMinimumSize(800, 600);
     }
 
     /**

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportDataConfirmPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportDataConfirmPage.java
@@ -100,6 +100,8 @@ public class ImportDataConfirmPage extends CMWizardPage {
         }
 
         infoTest.setText(confirmInfo == null ? "" : confirmInfo);
+        
+        getShell().setMinimumSize(880, 500);
     }
 
     private String makeExcelConfirmInfoText() {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportSettingExcelPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportSettingExcelPage.java
@@ -38,6 +38,8 @@ import com.cubrid.common.ui.spi.util.CommonUITool;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.eclipse.jface.dialogs.PageChangedEvent;
 import org.eclipse.jface.dialogs.PageChangingEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
@@ -466,5 +468,11 @@ public class ImportSettingExcelPage extends AbsImportSettingPage
     /** clear all options */
     public void clearOptions() {
         this.setInited(false);
+    }
+    
+    @Override
+    protected void afterShowCurrentPage(PageChangedEvent event) {
+        super.afterShowCurrentPage(event);
+        getShell().setMinimumSize(880, 600);
     }
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportSettingSQLPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportSettingSQLPage.java
@@ -42,6 +42,8 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.eclipse.jface.dialogs.PageChangedEvent;
 import org.eclipse.jface.dialogs.PageChangingEvent;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ComboBoxCellEditor;
@@ -514,6 +516,12 @@ public class ImportSettingSQLPage extends AbsImportSettingPage
     /** clear all options */
     public void clearOptions() {
         this.setInited(false);
+    }
+    
+    @Override
+    protected void afterShowCurrentPage(PageChangedEvent event) {
+        super.afterShowCurrentPage(event);
+        getShell().setMinimumSize(880, 420);
     }
 }
 

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportSettingTxtPage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportSettingTxtPage.java
@@ -38,6 +38,8 @@ import com.cubrid.common.ui.spi.util.CommonUITool;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.eclipse.jface.dialogs.PageChangedEvent;
 import org.eclipse.jface.dialogs.PageChangingEvent;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -631,5 +633,11 @@ public class ImportSettingTxtPage extends AbsImportSettingPage
     /** clear all options */
     public void clearOptions() {
         this.setInited(false);
+    }
+    
+    @Override
+    protected void afterShowCurrentPage(PageChangedEvent event) {
+        super.afterShowCurrentPage(event);
+        getShell().setMinimumSize(1000, 650);
     }
 }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportTypePage.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/imp/ImportTypePage.java
@@ -339,6 +339,7 @@ public class ImportTypePage extends AbsImportSettingPage {
                         }
                     });
         }
+        getShell().setMinimumSize(880, 550);
     }
 
     /** Verify the setting */
@@ -382,6 +383,8 @@ public class ImportTypePage extends AbsImportSettingPage {
         deleteButton.setEnabled(false);
 
         validate();
+        
+        getShell().setMinimumSize(880, 550);
     }
 
     protected void handlePageLeaving(PageChangingEvent event) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
@@ -749,7 +749,6 @@ public class EditUserDialog extends CMTrayDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(680, 650);
         getShell().setMinimumSize(730, 700);
         CommonUITool.centerShell(getShell());
         if (isNewFlag()) {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
@@ -750,6 +750,7 @@ public class EditUserDialog extends CMTrayDialog {
     protected void constrainShellSize() {
         super.constrainShellSize();
         getShell().setSize(680, 650);
+        getShell().setMinimumSize(730, 700);
         CommonUITool.centerShell(getShell());
         if (isNewFlag()) {
             getShell().setText(Messages.msgAddUserDialog);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/dialog/AddColumnDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/dialog/AddColumnDialog.java
@@ -91,7 +91,7 @@ public class AddColumnDialog extends CMTitleAreaDialog {
 
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(420, 255);
+        getShell().setMinimumSize(420, 255);
         CommonUITool.centerShell(getShell());
         getShell()
                 .setText(

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/dialog/ExportERDataDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/dialog/ExportERDataDialog.java
@@ -67,7 +67,7 @@ public class ExportERDataDialog extends CMTitleAreaDialog {
 
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(300, 293);
+        getShell().setMinimumSize(300, 293);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleChoose);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/er/dialog/SetPhysicalLogicaMapDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/er/dialog/SetPhysicalLogicaMapDialog.java
@@ -103,7 +103,7 @@ public class SetPhysicalLogicaMapDialog extends CMTitleAreaDialog
 
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(370, 420);
+        getShell().setMinimumSize(370, 420);
         getShell().setText(Messages.namePhysicalLogicalMapDlg);
     }
 

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/ExportResultDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/ExportResultDialog.java
@@ -237,7 +237,7 @@ public class ExportResultDialog extends CMTitleAreaDialog implements ModifyListe
     protected void constrainShellSize() {
         super.constrainShellSize();
         getShell().setText(Messages.exportShellTitle);
-        getShell().setSize(550, 280);
+        getShell().setMinimumSize(550, 280);
     }
 
     /**

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/GotoLineDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/GotoLineDialog.java
@@ -116,11 +116,12 @@ public final class GotoLineDialog extends Dialog {
     }
 
     protected void createContents() {
-        shell = new Shell(getParent(), SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
+        shell = new Shell(getParent(), SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL | SWT.RESIZE);
         final GridLayout gridLayout = new GridLayout();
         gridLayout.numColumns = 2;
         shell.setLayout(gridLayout);
-        shell.setSize(450, 100);
+        shell.setSize(300, 150);
+        shell.setMinimumSize(300, 150);
         shell.setText(Messages.gotoLineTitle);
 
         final Composite composite = new Composite(shell, SWT.NONE);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/MultiShardQueryDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/MultiShardQueryDialog.java
@@ -110,7 +110,7 @@ public class MultiShardQueryDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(430, 210);
+        getShell().setMinimumSize(430, 210);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.shardMultiQueryDialogTitle);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/ReformatColumnsAliasDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/ReformatColumnsAliasDialog.java
@@ -114,11 +114,12 @@ public final class ReformatColumnsAliasDialog extends Dialog {
     }
 
     protected void createContents() {
-        shell = new Shell(getParent(), SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
+        shell = new Shell(getParent(), SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL | SWT.RESIZE);
         final GridLayout gridLayout = new GridLayout();
         gridLayout.numColumns = 2;
         shell.setLayout(gridLayout);
-        shell.setSize(450, 100);
+        shell.setSize(500, 150);
+        shell.setMinimumSize(500, 150);
         shell.setText(Messages.reformatTableAliasTitle);
 
         final Composite composite = new Composite(shell, SWT.NONE);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/SetFileEncodingDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/query/dialog/SetFileEncodingDialog.java
@@ -154,7 +154,7 @@ public class SetFileEncodingDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(430, 240);
+        getShell().setMinimumSize(430, 240);
         if (isOpened) {
             getShell().setText(Messages.titleOpenFileDialog);
             setTitle(Messages.titleOpenFileDialogDetail);

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/table/button/InputTextDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/table/button/InputTextDialog.java
@@ -96,7 +96,7 @@ public class InputTextDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        this.getShell().setSize(450, 200);
+        this.getShell().setMinimumSize(450, 200);
         CommonUITool.centerShell(getShell());
         getShell().setText(title);
     }

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/table/celleditor/BLOBCellPopupDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/table/celleditor/BLOBCellPopupDialog.java
@@ -1055,7 +1055,7 @@ public class BLOBCellPopupDialog extends CMTitleAreaDialog implements ICellPopup
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(720, 540);
+        getShell().setMinimumSize(720, 540);
         getShell()
                 .addDisposeListener(
                         new DisposeListener() {

--- a/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/table/celleditor/LongTextCellPopupDialog.java
+++ b/com.cubrid.common.ui/src/com/cubrid/common/ui/spi/table/celleditor/LongTextCellPopupDialog.java
@@ -368,7 +368,7 @@ public class LongTextCellPopupDialog extends CMTitleAreaDialog implements ICellP
 
     /** Constrain the shell size */
     protected void constrainShellSize() {
-        getShell().setSize(640, 480);
+        getShell().setMinimumSize(640, 480);
         super.constrainShellSize();
         if (isEditable) {
             getShell().setText(Messages.titleEditData);

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/common/dialog/ShortSettingEditorConfigDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/common/dialog/ShortSettingEditorConfigDialog.java
@@ -104,7 +104,7 @@ public class ShortSettingEditorConfigDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(380, 220);
+        getShell().setMinimumSize(380, 220);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleSetEditorConfig);
         setMessage(Messages.msgSetEditorConfig);

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/BackupDatabaseDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/BackupDatabaseDialog.java
@@ -328,7 +328,7 @@ public class BackupDatabaseDialog extends CMTrayDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(500, 450);
+        getShell().setMinimumSize(500, 450);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleBackupDbDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/CheckDatabaseDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/CheckDatabaseDialog.java
@@ -150,7 +150,7 @@ public class CheckDatabaseDialog extends CMTitleAreaDialog implements ITaskExecu
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 400);
+        getShell().setMinimumSize(400, 400);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleCheckDbDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/DeleteDatabaseConfirmDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/DeleteDatabaseConfirmDialog.java
@@ -115,7 +115,7 @@ public class DeleteDatabaseConfirmDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(500, 220);
+        getShell().setMinimumSize(500, 220);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleDeleteDbConfirmDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/DeleteDatabaseDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/DeleteDatabaseDialog.java
@@ -362,7 +362,7 @@ public class DeleteDatabaseDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(550, 450);
+        getShell().setMinimumSize(550, 450);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleDeleteDbDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/LockInfoDetailDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/LockInfoDetailDialog.java
@@ -217,7 +217,7 @@ public class LockInfoDetailDialog extends CMTitleAreaDialog {
     protected void constrainShellSize() {
         super.constrainShellSize();
         CommonUITool.centerShell(getShell());
-        getShell().setSize(500, 600);
+        getShell().setMinimumSize(500, 600);
         getShell().setText(Messages.titleLockInfoDetailDialog);
     }
 

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/LockInfoDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/LockInfoDialog.java
@@ -271,7 +271,7 @@ public class LockInfoDialog extends CMTrayDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(650, 500);
+        getShell().setMinimumSize(650, 500);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleLockInfoDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/OptimizeDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/OptimizeDialog.java
@@ -180,7 +180,7 @@ public class OptimizeDialog extends CMTitleAreaDialog {
     protected void constrainShellSize() {
         super.constrainShellSize();
 
-        getShell().setSize(400, 520);
+        getShell().setMinimumSize(400, 520);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleOptimizeDbDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/ParamDumpDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/ParamDumpDialog.java
@@ -154,7 +154,7 @@ public class ParamDumpDialog extends CMTitleAreaDialog implements ITaskExecutorI
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 400);
+        getShell().setMinimumSize(400, 400);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleParamDumpDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/PlanDumpDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/PlanDumpDialog.java
@@ -149,7 +149,7 @@ public class PlanDumpDialog extends CMTitleAreaDialog implements ITaskExecutorIn
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 400);
+        getShell().setMinimumSize(400, 400);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titlePlanDumpDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/dbspace/dialog/AutoAddVolumeLogDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/dbspace/dialog/AutoAddVolumeLogDialog.java
@@ -161,7 +161,7 @@ public class AutoAddVolumeLogDialog extends CMTitleAreaDialog {
     protected void constrainShellSize() {
         super.constrainShellSize();
         CommonUITool.centerShell(getShell());
-        getShell().setSize(640, 500);
+        getShell().setMinimumSize(640, 500);
         getShell().setText(SHELL_VOLUME_LOG_TITLE);
     }
 

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/jobauto/dialog/BackupErrLogDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/jobauto/dialog/BackupErrLogDialog.java
@@ -155,7 +155,7 @@ public class BackupErrLogDialog extends CMTitleAreaDialog {
     protected void constrainShellSize() {
         super.constrainShellSize();
         CommonUITool.centerShell(getShell());
-        getShell().setSize(640, 500);
+        getShell().setMinimumSize(640, 500);
         getShell().setText(Messages.backupShellTitle);
     }
 

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/jobauto/dialog/QueryLogDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/jobauto/dialog/QueryLogDialog.java
@@ -154,7 +154,7 @@ public class QueryLogDialog extends CMTitleAreaDialog {
     protected void constrainShellSize() {
         super.constrainShellSize();
         CommonUITool.centerShell(getShell());
-        getShell().setSize(640, 500);
+        getShell().setMinimumSize(640, 500);
         getShell().setText(Messages.queryLogTitle);
     }
 

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/control/EditParameterDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/control/EditParameterDialog.java
@@ -128,7 +128,7 @@ public class EditParameterDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 300);
+        getShell().setMinimumSize(400, 300);
         CommonUITool.centerShell(getShell());
         getShell().setText("Edit parameter");
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/control/StartHAServiceDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/control/StartHAServiceDialog.java
@@ -183,7 +183,7 @@ public class StartHAServiceDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(700, 500);
+        getShell().setMinimumSize(700, 500);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleStartHAService);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/dialog/ChangePasswordDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/dialog/ChangePasswordDialog.java
@@ -155,7 +155,7 @@ public class ChangePasswordDialog extends CMTitleAreaDialog implements ModifyLis
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(500, 400);
+        getShell().setMinimumSize(500, 400);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleChangePasswordDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/dialog/GenCertDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/host/dialog/GenCertDialog.java
@@ -247,7 +247,7 @@ public class GenCertDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(500, 430);
+        getShell().setMinimumSize(500, 430);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleGenCertDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/logs/dialog/SqlLogAnalyzeResultDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/logs/dialog/SqlLogAnalyzeResultDialog.java
@@ -537,7 +537,7 @@ public class SqlLogAnalyzeResultDialog extends CMTitleAreaDialog {
                                                 logPath, CasRunnerConfigDialog.getDbname(), node);
                                         casRunnerResultViewDialog.setTotalResultNum(
                                                 Integer.parseInt(totalResultNum));
-                                        casRunnerResultViewDialog.getShell().setSize(665, 555);
+                                        casRunnerResultViewDialog.getShell().setMinimumSize(665, 555);
                                         casRunnerResultViewDialog.open();
                                     }
                                 }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/mondashboard/dialog/ConnectDatabaseNodeDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/mondashboard/dialog/ConnectDatabaseNodeDialog.java
@@ -116,7 +116,7 @@ public class ConnectDatabaseNodeDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 240);
+        getShell().setMinimumSize(400, 240);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleLoginDbDialog);
     }

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/mondashboard/dialog/ConnectHostNodeDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/mondashboard/dialog/ConnectHostNodeDialog.java
@@ -187,7 +187,7 @@ public class ConnectHostNodeDialog extends CMTitleAreaDialog implements ModifyLi
     protected void constrainShellSize() {
         super.constrainShellSize();
         CommonUITool.centerShell(getShell());
-        getShell().setSize(500, 400);
+        getShell().setMinimumSize(500, 400);
         getShell().setText(Messages.titileHostInfoPage);
     }
 

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/replication/dialog/ChangeMasterDbDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/replication/dialog/ChangeMasterDbDialog.java
@@ -147,7 +147,7 @@ public class ChangeMasterDbDialog extends CMTitleAreaDialog implements ModifyLis
     protected void constrainShellSize() {
         super.constrainShellSize();
         CommonUITool.centerShell(getShell());
-        getShell().setSize(400, 300);
+        getShell().setMinimumSize(400, 300);
         getShell().setText(Messages.chmsdb0titleChangeMasterDbDialog);
     }
 

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/replication/dialog/ReplServerDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/replication/dialog/ReplServerDialog.java
@@ -204,7 +204,7 @@ public class ReplServerDialog extends CMTitleAreaDialog implements ModifyListene
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 380);
+        getShell().setMinimumSize(400, 380);
         CommonUITool.centerShell(getShell());
         if (this.isStartReplServer) {
             getShell().setText(Messages.titleStartReplServer);

--- a/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/replication/editor/dialog/SetHostInfoDialog.java
+++ b/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/replication/editor/dialog/SetHostInfoDialog.java
@@ -185,7 +185,7 @@ public class SetHostInfoDialog extends CMTitleAreaDialog implements ModifyListen
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(400, 300);
+        getShell().setMinimumSize(400, 300);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleSetHostInfoDialog);
     }

--- a/com.cubrid.cubridquery.ui/src/com/cubrid/cubridquery/ui/common/dialog/ShortSettingEditorConfigDialog.java
+++ b/com.cubrid.cubridquery.ui/src/com/cubrid/cubridquery/ui/common/dialog/ShortSettingEditorConfigDialog.java
@@ -104,7 +104,7 @@ public class ShortSettingEditorConfigDialog extends CMTitleAreaDialog {
     /** Constrain the shell size */
     protected void constrainShellSize() {
         super.constrainShellSize();
-        getShell().setSize(360, 240);
+        getShell().setMinimumSize(360, 240);
         CommonUITool.centerShell(getShell());
         getShell().setText(Messages.titleSetEditorConfig);
         setMessage(Messages.msgSetEditorConfig);


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4739

Purpose
Wizard, Dialog등에서 사이즈가 자동으로 설정되도록 최소 사이즈만 설정하도록 합니다.

Implementation
- In wizards and dialogs, only the minimum size is set so that components can automatically grow
- the size can be changed.

Remark
For CA