### PR TITLE
[TOOLS-4747] issues that occurred after updating Eclipse 2025-06, JDK21 and Maven

### DIFF
--- a/features/com.cubrid.cubridmanager.dependence.feature/pom.xml
+++ b/features/com.cubrid.cubridmanager.dependence.feature/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>3.6.3</version>
+            <version>3.8.1</version>
         </dependency>
     </dependencies>
 

--- a/plugins/com.cubrid.cubridmanager.app/plugin.xml
+++ b/plugins/com.cubrid.cubridmanager.app/plugin.xml
@@ -29,10 +29,6 @@
                value="icons/cubridmanager16.gif,icons/cubridmanager32.gif,icons/cubridmanager48.gif,icons/cubridmanager64.gif">
          </property>
           <property
-               name="preferenceCustomization"
-               value="plugin_customization.ini">
-         </property>
-          <property
                 name="startupForegroundColor"
                 value="C0C0C0">
           </property>
@@ -43,6 +39,10 @@
           <property
                 name="startupProgressRect"
                 value="5,380,557,15">
+          </property>
+          <property
+                name="preferenceCustomization"
+                value="plugin_customization.ini">
           </property>
       </product>
    </extension>

--- a/site/com.cubrid.cubridmanager.p2.site/pom.xml
+++ b/site/com.cubrid.cubridmanager.p2.site/pom.xml
@@ -37,7 +37,6 @@
                                 <artifact><id>org.slf4j:jcl-over-slf4j:${slf4j.version}</id></artifact>
                                 <artifact><id>org.slf4j:slf4j-log4j12:${slf4j.version}</id></artifact>
                                 <artifact><id>jakarta.xml.bind:jakarta.xml.bind-api:4.0.0</id></artifact>
-                                <artifact><id>com.sun.xml.bind:jaxb-impl:4.0.0</id></artifact>
                             </artifacts>
                         </configuration>
                     </execution>

--- a/testfragment/com.cubrid.cubridmanager.jdbc.proxy.testfragment/META-INF/MANIFEST.MF
+++ b/testfragment/com.cubrid.cubridmanager.jdbc.proxy.testfragment/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: com.cubrid.cubridmanager.jdbc.proxy.testfragment
 Bundle-Version: 9.3.1.qualifier
 Bundle-Vendor: CUBRID
 Fragment-Host: com.cubrid.cubridmanager.jdbc.proxy;bundle-version="9.3.1"
-Require-Bundle: org.junit,
- com.cubrid.cubridmanager.jdbc.proxy
+Require-Bundle: org.junit
+Bundle-ClassPath: .
 Automatic-Module-Name: com.cubrid.cubridmanager.jdbc.proxy.testfragment

--- a/testfragment/pom.xml
+++ b/testfragment/pom.xml
@@ -14,7 +14,7 @@
     
     <modules>
         <module>com.cubrid.common.core.testfragment</module>
-	<module>com.cubrid.cubridmanager.core.testfragment</module>
+        <module>com.cubrid.cubridmanager.core.testfragment</module>
         <module>com.cubrid.cubridmanager.jdbc.proxy.testfragment</module>
     </modules>
 </project>


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4747

Purpose
- Eclipse 사용시 자동으로 변경, 자동 빌드 오류 문제 수정
- dependabot에 의해 maven-compat 버전 업데이트를 적용합니다.,

Implementation
- Remove unused libs from pom.xml in p2-site.
- Remove line breaks.
- Automatically apply changes in Eclipse.
- Add missing options to MANIFEST.MF.
- org.apache.maven:maven-compat from 3.6.3 to 3.8.1. by dependabot