### PR TITLE
[TOOLS-4756] Foreign key issue when using JDBC 11.3.0 or later version in EditTable

### DIFF
--- a/plugins/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetSchemaTask.java
+++ b/plugins/com.cubrid.cubridmanager.core/src/com/cubrid/cubridmanager/core/cubrid/table/task/GetSchemaTask.java
@@ -458,7 +458,6 @@ public class GetSchemaTask extends JDBCTask {
                 fkInfo.put("PKTABLE_CAT", rs.getString("PKTABLE_CAT"));
                 fkInfo.put("PKTABLE_SCHEM", rs.getString("PKTABLE_SCHEM"));
                 String pkTableName = rs.getString("PKTABLE_NAME");
-                ;
                 String fkTableName = rs.getString("FKTABLE_NAME");
                 if (databaseInfo.isSupportUserSchema()) {
                     pkTableName = schemaNameToUpperCase(pkTableName);
@@ -609,7 +608,15 @@ public class GetSchemaTask extends JDBCTask {
                         Map<String, String> fkInfo = foreignKeys.get(attrName);
                         if (null != fkInfo) {
                             String referencedTable = c.getReferencedTable();
-                            String pkTable = fkInfo.get("PKTABLE_NAME");
+                            String pkTable;
+                            if (isSupportUserSchema) {
+                                pkTable = fkInfo.get("PKTABLE_NAME");
+                                if (pkTable.indexOf(".") == -1) {
+                                    pkTable = fkInfo.get("PKTABLE_SCHEM") + "." + pkTable;
+                                }
+                            } else {
+                                pkTable = fkInfo.get("PKTABLE_NAME");
+                            }
                             if (StringUtil.isEqual(referencedTable, pkTable)) {
                                 continue;
                             }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4756

Purpose
11.3.0 이상의 JDBC에서 부터 PKTABLE_NAME에 Schema 정보가 포함되지 않아
Schema정보가 없을 경우에 PKSCHEMA_NAME을 추가로 사용하도록 수정합니다.

Implementation
- Modify to process as is when 'PKTABLE_NAME' has schema.