### PR TITLE
[TOOLS-4775] cross-OS environment issues.

### DIFF
--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/control/XlsxWriterHelper.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/control/XlsxWriterHelper.java
@@ -37,6 +37,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Calendar;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -327,6 +329,7 @@ public class XlsxWriterHelper { // FIXME move this logic to core module
             }
         } finally {
             FileUtil.close(zos);
+            zip.close();
         }
     }
 
@@ -360,38 +363,38 @@ public class XlsxWriterHelper { // FIXME move this logic to core module
             Map<String, File> fileMap,
             File outFile)
             throws IOException {
-        String templateFileName = System.nanoTime() + "template.xlsx";
+        Path templatePath = Files.createTempFile("template", ".xlsx");
+        File tempFile = templatePath.toFile();
+        tempFile.deleteOnExit();
         FileOutputStream os = null;
         try {
-            os = new FileOutputStream(templateFileName);
+            os = new FileOutputStream(tempFile);
             workbook.write(os);
         } finally {
             FileUtil.close(os);
-
             FileOutputStream out = null;
             try {
                 out = new FileOutputStream(outFile);
                 if (xlsxWriterhelper != null) {
-                    xlsxWriterhelper.substitute(new File(templateFileName), fileMap, out);
+                    xlsxWriterhelper.substitute(tempFile, fileMap, out);
                 }
             } finally {
                 FileUtil.close(out);
-                deleteTempFiles(fileMap, templateFileName);
+                deleteTempFiles(fileMap, templatePath);
             }
         }
     }
 
-    private static void deleteTempFiles(Map<String, File> fileMap, String templateFileName) {
+    private static void deleteTempFiles(Map<String, File> fileMap, Path templatePath) {
         boolean isSuccess = true;
         Iterator<File> fileIt = fileMap.values().iterator();
         while (fileIt.hasNext()) {
             File file = fileIt.next();
             isSuccess = file.delete();
         }
-        File file = new File(templateFileName);
         try {
-            if (file.exists() && isSuccess) {
-                isSuccess = file.delete();
+            if (templatePath.toFile().exists() && isSuccess) {
+                Files.delete(templatePath);
             }
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
@@ -161,7 +161,7 @@ public class EditUserDialog extends CMTrayDialog {
         parentComp = (Composite) super.createDialogArea(parent);
 
         tabFolder = new CTabFolder(parentComp, SWT.NONE);
-        tabFolder.setLayoutData(new GridData(GridData.FILL_BOTH));
+        tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         GridLayout layout = new GridLayout();
         tabFolder.setLayout(layout);
 

--- a/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/BackupDatabaseDialog.java
+++ b/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/database/dialog/BackupDatabaseDialog.java
@@ -124,7 +124,7 @@ public class BackupDatabaseDialog extends CMTrayDialog {
     protected Control createDialogArea(Composite parent) {
         Composite parentComp = (Composite) super.createDialogArea(parent);
         tabFolder = new CTabFolder(parentComp, SWT.NONE);
-        tabFolder.setLayoutData(new GridData(GridData.FILL_BOTH));
+        tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         GridLayout layout = new GridLayout();
         tabFolder.setLayout(layout);
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4775

Purpose
- in Windows, fixed issue (temp file is not deleted when export xlsl)
- in Linux, fixed issue ( value is not displayed in Tableviewer on EditUserDialog)

Implementation
- xlsl temp 사용 후 닫지 않는 문제를 해결하고 문제가 발생 될 경우 jvm에 종료 시 삭제 되도록 적용
- TabFolder사용 시 두개의 tab에서 TableViewer가 업데이트 되지 않는 문제를 수정합니다.
EditUserDialog, BackupDatabaseDialog에 적용합니다.