### PR TITLE
[TOOLS-4778] Issue that occur after Eclipse update

### DIFF
--- a/plugins/com.cubrid.common.core/META-INF/MANIFEST.MF
+++ b/plugins/com.cubrid.common.core/META-INF/MANIFEST.MF
@@ -10,6 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.ant,
  jakarta.xml.bind-api,
  org.glassfish.hk2.osgi-resource-locator,
+ com.sun.xml.bind.jaxb-core,
+ com.sun.xml.bind.jaxb-impl,
  ch.qos.logback.classic,
  ch.qos.logback.core,
  slf4j.api

--- a/plugins/com.cubrid.common.ui/META-INF/MANIFEST.MF
+++ b/plugins/com.cubrid.common.ui/META-INF/MANIFEST.MF
@@ -23,6 +23,8 @@ Require-Bundle: org.eclipse.jface.text,
  com.cubrid.cubridmanager.jdbc.proxy,
  jakarta.xml.bind-api,
  org.glassfish.hk2.osgi-resource-locator,
+ com.sun.xml.bind.jaxb-core,
+ com.sun.xml.bind.jaxb-impl,
  slf4j.api
 Bundle-Localization: plugin
 Eclipse-LazyStart: true

--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/dialog/EditUserDialog.java
@@ -184,6 +184,7 @@ public class EditUserDialog extends CMTrayDialog {
             authItem.dispose();
         }
 
+        tabFolder.setSelection(0);
         userNameText.setFocus();
         return parentComp;
     }
@@ -195,7 +196,7 @@ public class EditUserDialog extends CMTrayDialog {
      */
     private Composite createUserComposite() {
         final Composite composite = new Composite(tabFolder, SWT.NONE);
-        composite.setLayoutData(new GridData(GridData.FILL_BOTH));
+        tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         GridLayout layout = new GridLayout();
         composite.setLayout(layout);
 
@@ -420,9 +421,9 @@ public class EditUserDialog extends CMTrayDialog {
                         }
                         allUserTable.remove(idx);
                         setBtnEnableDisable();
-                        packTable(allUserTable);
-                        packTable(userGroupTable);
-                        packTable(memberTableViewer.getTable());
+                        userGroupTable.update();
+                        allUserTable.update();
+                        memberTableViewer.getTable().update();
                     }
                 });
 
@@ -470,12 +471,11 @@ public class EditUserDialog extends CMTrayDialog {
                             TableItem item = new TableItem(allUserTable, SWT.NONE);
                             item.setText(0, userGroupTable.getItem(i).getText(0));
                         }
-
                         userGroupTable.remove(idxs);
                         setBtnEnableDisable();
-                        packTable(allUserTable);
-                        packTable(userGroupTable);
-                        packTable(memberTableViewer.getTable());
+                        allUserTable.update();
+                        userGroupTable.update();
+                        memberTableViewer.getTable().update();
                     }
                 });
         new Label(cmpRightAreaGroup, SWT.NONE);

--- a/site/com.cubrid.cubridmanager.p2.site/pom.xml
+++ b/site/com.cubrid.cubridmanager.p2.site/pom.xml
@@ -37,6 +37,7 @@
                                 <artifact><id>org.slf4j:jcl-over-slf4j:${slf4j.version}</id></artifact>
                                 <artifact><id>org.slf4j:slf4j-log4j12:${slf4j.version}</id></artifact>
                                 <artifact><id>jakarta.xml.bind:jakarta.xml.bind-api:4.0.0</id></artifact>
+                                <artifact><id>com.sun.xml.bind:jaxb-impl:4.0.2</id></artifact>
                             </artifacts>
                         </configuration>
                     </execution>

--- a/site/com.cubrid.cubridmanager.p2.site/pom.xml
+++ b/site/com.cubrid.cubridmanager.p2.site/pom.xml
@@ -36,8 +36,7 @@
                                 <artifact><id>org.slf4j:slf4j-api:${slf4j.version}</id></artifact>
                                 <artifact><id>org.slf4j:jcl-over-slf4j:${slf4j.version}</id></artifact>
                                 <artifact><id>org.slf4j:slf4j-log4j12:${slf4j.version}</id></artifact>
-                                <artifact><id>jakarta.xml.bind:jakarta.xml.bind-api:4.0.0</id></artifact>
-                                <artifact><id>com.sun.xml.bind:jaxb-impl:4.0.2</id></artifact>
+                                <artifact><id>com.sun.xml.bind:jaxb-impl:4.0.5</id></artifact>
                             </artifacts>
                         </configuration>
                     </execution>


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4778

Purpose
- Add Runtime lib for ERwin Export.
- Table is not updated when add or remove group in EditUserDialog.
- First tab contents is not displayed after tabitem disposed in EditUserDialog. (only dba group).

Implementation
- ERwin Export시 사용하는 jakarta.xml.bind-api의 Runtime Library가 누락되었습니다. (p2-site 및 Manifest.MF)
- eclipse 2025-06버전에서는 Table 업데이트 시 pack만으로는 table 내용이 업데이트 되지 않아 update로 대체합니다.
(크기 조절은 불필요하다고 생가합니다.)
- eclipse 2025-06버전에서 생성 후 tabitem을 disposed시 tab 내용이 보이지 않는 문제가 발생하여 강제로 tab을 이동하도록 수정합니다.
