### PR TITLE
[TOOLS-4779] Feature Improvement Requests For CA 12.0.0

### DIFF
--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages.java
@@ -497,6 +497,7 @@ public class Messages extends NLS {
     public static String grpOnDelete;
     public static String errNoTableName;
     public static String btnOnCacheObject;
+    public static String infoNoInputSemicolon;
 
     public static String typeClass;
     public static String typeInstance;

--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages.properties
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages.properties
@@ -455,6 +455,7 @@ errFileCannotDelete=Cannot delete the "{0}" file
 errFileCannotRename=Cannot rename "{0}" file to "{1}"
 errNoTableName=Please input a table name.
 btnOnCacheObject=On &Cache Object
+infoNoInputSemicolon=Semicolons (;) cannot be entered.
 typeClass=C&lass
 typeTable=Table
 typeView=View

--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages_ko_KR.properties
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/Messages_ko_KR.properties
@@ -455,6 +455,7 @@ errFileCannotDelete={0}\ud30c\uc77c\uc744 \uc0ad\uc81c\ud560 \uc218 \uc5c6\uc2b5
 errFileCannotRename={0}\ub97c {1}\ub85c \uc774\ub984\uc744 \ubcc0\uacbd\ud560 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4.
 errNoTableName=\ud14c\uc774\ube14 \uc774\ub984\uc744 \uc785\ub825\ud558\uc2ed\uc2dc\uc624.
 btnOnCacheObject=ON CACHE OBJECT
+infoNoInputSemicolon=\uC138\uBBF8\uCF5C\uB860(;)\uC740 \uC785\uB825\uD560 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
 typeClass=CLASS(&L)
 typeTable=TABLE
 typeView=VIEW

--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddQueryDialog.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddQueryDialog.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.VerifyEvent;
+import org.eclipse.swt.events.VerifyListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -122,6 +124,15 @@ public class AddQueryDialog extends CMTitleAreaDialog {
         group.setText(Messages.grpQuerySpecification);
         sqlSpecText = new Text(group, SWT.BORDER | SWT.WRAP | SWT.MULTI | SWT.V_SCROLL);
         sqlSpecText.setLayoutData(new GridData(GridData.FILL_BOTH));
+
+        sqlSpecText.addVerifyListener(new VerifyListener() {
+            @Override
+            public void verifyText(VerifyEvent e) {
+                if (e.text.contains(";")) {
+                    e.doit = false;
+                }
+            }
+        });
     }
 
     /** initializes some values */

--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddQueryDialog.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/AddQueryDialog.java
@@ -130,6 +130,7 @@ public class AddQueryDialog extends CMTitleAreaDialog {
             public void verifyText(VerifyEvent e) {
                 if (e.text.contains(";")) {
                     e.doit = false;
+                    CommonUITool.openInformationBox(Messages.infoNoInputSemicolon);
                 }
             }
         });

--- a/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/jobauto/control/PeriodGroup.java
+++ b/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/cubrid/jobauto/control/PeriodGroup.java
@@ -422,6 +422,7 @@ public class PeriodGroup extends Observable {
          */
         public void modifyText(ModifyEvent event) {
             detailsForType(typeCombo);
+            dialog.getShell().pack();
         }
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4779

Purpose
- Added auto-resize when changing the type of dialog box for job automation.
- Fixed the Add Query dialog in the Add (Edit) view to not allow semicolons to be entered.

Implementation
-  job automation의 백업, 쿼리 자동화 다이얼로그에서 type 변경 시 dialog 내 component가 추가,삭제되어 변경되어
작은 크기에서 큰 크기로 조절될 때 메뉴가 보이지 않아 자동으로 사이즈 조절되도록 수정.
- View 추가 시 질의는 세미콜론을 포함하면 오류가 발생되도록 구현되어 있어 세미콜론을 입력 할 수 없도록 수정.