### PR TITLE
[TOOLS-4781] issues with previous versions.

### DIFF
--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/ExportTableDefinitionDialog.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/table/dialog/ExportTableDefinitionDialog.java
@@ -206,7 +206,7 @@ public class ExportTableDefinitionDialog extends CMTitleAreaDialog {
         type2Btn.setLayoutData(CommonUITool.createGridData(1, 1, -1, -1));
         type2Btn.setText(Messages.exportTableDefinitionExcelLayoutTypeGeneric);
         type2Btn.setSelection(false);
-        type1Btn.addSelectionListener(
+        type2Btn.addSelectionListener(
                 new SelectionAdapter() {
                     public void widgetSelected(SelectionEvent e) {
                         exportLayoutType = 2;

--- a/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/action/DeleteUserAction.java
+++ b/plugins/com.cubrid.common.ui/src/com/cubrid/common/ui/cubrid/user/action/DeleteUserAction.java
@@ -41,6 +41,7 @@ import com.cubrid.common.ui.spi.model.DefaultCubridNode;
 import com.cubrid.common.ui.spi.model.ICubridNode;
 import com.cubrid.common.ui.spi.model.ICubridNodeLoader;
 import com.cubrid.common.ui.spi.model.ISchemaNode;
+import com.cubrid.common.ui.spi.model.NodeType;
 import com.cubrid.common.ui.spi.progress.CommonTaskExec;
 import com.cubrid.common.ui.spi.progress.ExecTaskWithProgress;
 import com.cubrid.common.ui.spi.progress.TaskExecutor;
@@ -104,7 +105,11 @@ public class DeleteUserAction extends SelectionAction {
         if (!(obj instanceof ISchemaNode)) {
             return false;
         }
+
         ISchemaNode node = (ISchemaNode) obj;
+        if (node.getType() != null && !NodeType.USER.equals(node.getType())) {
+            return false;
+        }
         CubridDatabase database = node.getDatabase();
         if (database != null
                 && database.getRunningType() == DbRunningType.CS


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4781

Purpose
- Fixed issue for drop user action enable.
- Fixed issue simple type in ExportTableDefinitionDialog

Implementation
- drop user action에서 'User' node type가 아닐 경우 support 하지 않도록 수정.
- ExportTableDefinitionDialog에서 type selection 리스너 등록 오류.