### PR TITLE
[TOOLS-4788] HA status is not update in Service Dashboard

### DIFF
--- a/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/service/editor/ServiceDashboardEditor.java
+++ b/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/service/editor/ServiceDashboardEditor.java
@@ -1028,9 +1028,7 @@ public class ServiceDashboardEditor extends CubridEditorPart {
     }
 
     private void setHaStatusInfo(ServiceDashboardInfo sDashInfo, HAHostStatusInfo info) {
-        if (info != null) {
-            sDashInfo.getServer().getServerInfo().setHaHostStatusInfo(info);
-        }
+        sDashInfo.getServer().getServerInfo().setHaHostStatusInfo(info);
     }
 
     /** Get Selected Dashboard Item */

--- a/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/model/loader/CubridServerLoader.java
+++ b/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/model/loader/CubridServerLoader.java
@@ -242,9 +242,7 @@ public class CubridServerLoader extends CubridNodeLoader {
             server.getServerInfo().setHaHostName(getHeartbeatNodeInfoTask.getCurrentHostName());
             HAHostStatusInfo haHostStatusInfo =
                     getHeartbeatNodeInfoTask.getHostStatusInfo(server.getServerInfo());
-            if (haHostStatusInfo != null) {
-                server.getServerInfo().setHaHostStatusInfo(haHostStatusInfo);
-            }
+            server.getServerInfo().setHaHostStatusInfo(haHostStatusInfo);
         } else {
             LOGGER.debug("Get host status error:" + getHeartbeatNodeInfoTask.getErrorMsg());
         }

--- a/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/util/HAUtil.java
+++ b/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/util/HAUtil.java
@@ -342,8 +342,9 @@ public final class HAUtil {
             haDbStatusInfo.setStatusType(
                     serverInfo.isHAMode(dbName) ? DBStatusType.STOPPED_HA : DBStatusType.STOPPED);
         }
+
+        haDbStatusInfo.setHaHostStatusInfo(haHostStatusInfo);
         if (haHostStatusInfo != null) {
-            haDbStatusInfo.setHaHostStatusInfo(haHostStatusInfo);
             haHostStatusInfo.addHADatabaseStatus(haDbStatusInfo);
         }
         return haDbStatusInfo;


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4788

Implementation
HAHostStatus는 정보가 없더라도 업데이트 되도록 수정합니다. (Navigator, Monitoring 포함)

Purpose
HA모드가 중지되었을 때 HA 상태정보를 업데이트 하지 않는 문제를 수정합니다.
