### PR TITLE
[TOOLS-4793] Duplicate hosts will not connect in 'import host info' feature.

### DIFF
--- a/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/persist/CMHostNodePersistManager.java
+++ b/plugins/com.cubrid.cubridmanager.ui/src/com/cubrid/cubridmanager/ui/spi/persist/CMHostNodePersistManager.java
@@ -266,12 +266,14 @@ public final class CMHostNodePersistManager {
                 QueryOptions.load(optionPath, serverInfo);
             }
             servers.add(server);
-            ServerManager.getInstance()
-                    .addServer(
-                            serverInfo.getHostAddress(),
-                            serverInfo.getHostMonPort(),
-                            serverInfo.getUserName(),
-                            serverInfo);
+            if (serverInfo.getUserPassword() != null) {
+                ServerManager.getInstance()
+                        .addServer(
+                                serverInfo.getHostAddress(),
+                                serverInfo.getHostMonPort(),
+                                serverInfo.getUserName(),
+                                serverInfo);
+            }
         }
         return isHasLocalHost;
     }


### PR DESCRIPTION
http://jira.cubrid.org/browse/TOOLS-4793

Purpose
- import host info 기능 사용 시 server 정보를 node에서 가져올때는 userpassword가 null 이기 때문에
이때는 ServerManager에 저장하지 않도록 합니다.

Implementation
- If Userpassword is null, do not save it to ServerManager.